### PR TITLE
Add capsule types

### DIFF
--- a/.warpforge/catalog/alpinelinux.org/alpine/mirrors.json
+++ b/.warpforge/catalog/alpinelinux.org/alpine/mirrors.json
@@ -1,7 +1,9 @@
 {
-	"byWare": {
-		"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": [
-			"https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
-		]
+	"catalogmirrors.v1": {
+		"byWare": {
+			"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": [
+				"https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
+			]
+		}
 	}
 }

--- a/.warpforge/catalog/alpinelinux.org/alpine/module.json
+++ b/.warpforge/catalog/alpinelinux.org/alpine/module.json
@@ -1,7 +1,9 @@
 {
-	"name": "alpinelinux.org/alpine",
-	"releases": {
-		"v3.15.0": "zM5K3WcNp7K5hKapbeaVKZmmTQuN8uhXcvzQSX3AKSEbAtc6QhZHQJLk3ZNeM47Ga81iGdU"
-	},
-	"metadata": {}
+	"catalogmodule.v1": {
+		"name": "alpinelinux.org/alpine",
+		"releases": {
+			"v3.15.0": "zM5K3WcNp7K5hKapbeaVKZmmTQuN8uhXcvzQSX3AKSEbAtc6QhZHQJLk3ZNeM47Ga81iGdU"
+		},
+		"metadata": {}
+	}
 }

--- a/cmd/warpforge/catalog.go
+++ b/cmd/warpforge/catalog.go
@@ -498,7 +498,7 @@ func cmdCatalogRelease(c *cli.Context) error {
 		Recursive: false,
 	}
 	logger := logging.NewLogger(c.App.Writer, c.App.ErrWriter, c.Bool("json"), c.Bool("quiet"), c.Bool("verbose"))
-	results, err := plotexec.Exec(wsSet, plot, config, logger)
+	results, err := plotexec.Exec(wsSet, wfapi.PlotCapsule{Plot: &plot}, config, logger)
 	if err != nil {
 		return err
 	}

--- a/cmd/warpforge/check.go
+++ b/cmd/warpforge/check.go
@@ -23,8 +23,8 @@ func checkModule(fileName string) (*ipld.Node, error) {
 		return nil, err
 	}
 
-	module := wfapi.Module{}
-	n, err := ipld.Unmarshal([]byte(f), json.Decode, &module, wfapi.TypeSystem.TypeByName("Module"))
+	moduleCapsule := wfapi.ModuleCapsule{}
+	n, err := ipld.Unmarshal([]byte(f), json.Decode, &moduleCapsule, wfapi.TypeSystem.TypeByName("ModuleCapsule"))
 	return &n, err
 }
 

--- a/cmd/warpforge/ferk.go
+++ b/cmd/warpforge/ferk.go
@@ -138,7 +138,7 @@ func cmdFerk(c *cli.Context) error {
 			Interactive:        !c.Bool("no-interactive"),
 		},
 	}
-	_, err = plotexec.Exec(wss, plot, config, logger)
+	_, err = plotexec.Exec(wss, wfapi.PlotCapsule{Plot: &plot}, config, logger)
 	if err != nil {
 		return err
 	}

--- a/cmd/warpforge/quickstart.go
+++ b/cmd/warpforge/quickstart.go
@@ -17,36 +17,38 @@ var quickstartCmdDef = cli.Command{
 }
 
 const defaultPlotJson = `{
-	"inputs": {
-		"rootfs": "catalog:min.warpforge.io/alpinelinux/rootfs:v3.15.4:amd64"
-	},
-	"steps": {
-		"hello-world": {
-			"protoformula": {
-				"inputs": {
-					"/": "pipe::rootfs"
-				},
-				"action": {
-					"script": {
-						"interpreter": "/bin/sh",
-						"contents": [
-							"mkdir /output",
-							"echo 'hello world' | tee /output/file"
-						],
-						"network": false
-					}
-				},
-				"outputs": {
-					"out": {
-						"from": "/output",
-						"packtype": "tar"
+	"plot.v1": {
+		"inputs": {
+			"rootfs": "catalog:min.warpforge.io/alpinelinux/rootfs:v3.15.4:amd64"
+		},
+		"steps": {
+			"hello-world": {
+				"protoformula": {
+					"inputs": {
+						"/": "pipe::rootfs"
+					},
+					"action": {
+						"script": {
+							"interpreter": "/bin/sh",
+							"contents": [
+								"mkdir /output",
+								"echo 'hello world' | tee /output/file"
+							],
+							"network": false
+						}
+					},
+					"outputs": {
+						"out": {
+							"from": "/output",
+							"packtype": "tar"
+						}
 					}
 				}
 			}
+		},
+		"outputs": {
+			"output": "pipe:hello-world:out"
 		}
-	},
-	"outputs": {
-		"output": "pipe:hello-world:out"
 	}
 }
 `
@@ -68,10 +70,12 @@ func cmdQuickstart(c *cli.Context) error {
 
 	moduleName := c.Args().First()
 
-	module := wfapi.Module{
-		Name: wfapi.ModuleName(moduleName),
+	moduleCapsule := wfapi.ModuleCapsule{
+		Module: &wfapi.Module{
+			Name: wfapi.ModuleName(moduleName),
+		},
 	}
-	moduleSerial, err := ipld.Marshal(json.Encode, &module, wfapi.TypeSystem.TypeByName("Module"))
+	moduleSerial, err := ipld.Marshal(json.Encode, &moduleCapsule, wfapi.TypeSystem.TypeByName("ModuleCapsule"))
 	if err != nil {
 		return fmt.Errorf("failed to serialize module")
 	}
@@ -80,12 +84,12 @@ func cmdQuickstart(c *cli.Context) error {
 		return fmt.Errorf("failed to write module.json file: %s", err)
 	}
 
-	plot := wfapi.Plot{}
-	_, err = ipld.Unmarshal([]byte(defaultPlotJson), json.Decode, &plot, wfapi.TypeSystem.TypeByName("Plot"))
+	plotCapsule := wfapi.PlotCapsule{}
+	_, err = ipld.Unmarshal([]byte(defaultPlotJson), json.Decode, &plotCapsule, wfapi.TypeSystem.TypeByName("PlotCapsule"))
 	if err != nil {
 		return fmt.Errorf("failed to deserialize default plot")
 	}
-	plotSerial, err := ipld.Marshal(json.Encode, &plot, wfapi.TypeSystem.TypeByName("Plot"))
+	plotSerial, err := ipld.Marshal(json.Encode, &plotCapsule, wfapi.TypeSystem.TypeByName("PlotCapsule"))
 	if err != nil {
 		return fmt.Errorf("failed to serialize plot")
 	}

--- a/cmd/warpforge/run.go
+++ b/cmd/warpforge/run.go
@@ -71,7 +71,7 @@ func execModule(c *cli.Context, fileName string) (wfapi.PlotResults, error) {
 			DisableMemoization: c.Bool("force"),
 		},
 	}
-	result, err = plotexec.Exec(wss, plot, config, logger)
+	result, err = plotexec.Exec(wss, wfapi.PlotCapsule{Plot: &plot}, config, logger)
 	cdErr := os.Chdir(pwd)
 	if cdErr != nil {
 		return result, cdErr

--- a/cmd/warpforge/util.go
+++ b/cmd/warpforge/util.go
@@ -69,13 +69,16 @@ func plotFromFile(filename string) (wfapi.Plot, error) {
 		return wfapi.Plot{}, err
 	}
 
-	plot := wfapi.Plot{}
-	_, err = ipld.Unmarshal(f, json.Decode, &plot, wfapi.TypeSystem.TypeByName("Plot"))
+	plotCapsule := wfapi.PlotCapsule{}
+	_, err = ipld.Unmarshal(f, json.Decode, &plotCapsule, wfapi.TypeSystem.TypeByName("PlotCapsule"))
 	if err != nil {
 		return wfapi.Plot{}, err
 	}
+	if plotCapsule.Plot == nil {
+		return wfapi.Plot{}, fmt.Errorf("no v1 Plot in PlotCapsule")
+	}
 
-	return plot, nil
+	return *plotCapsule.Plot, nil
 }
 
 // takes a path to a module file, returns a module
@@ -85,11 +88,14 @@ func moduleFromFile(filename string) (wfapi.Module, error) {
 		return wfapi.Module{}, err
 	}
 
-	module := wfapi.Module{}
-	_, err = ipld.Unmarshal(f, json.Decode, &module, wfapi.TypeSystem.TypeByName("Module"))
+	moduleCapsule := wfapi.ModuleCapsule{}
+	_, err = ipld.Unmarshal(f, json.Decode, &moduleCapsule, wfapi.TypeSystem.TypeByName("ModuleCapsule"))
 	if err != nil {
 		return wfapi.Module{}, err
 	}
+	if moduleCapsule.Module == nil {
+		return wfapi.Module{}, fmt.Errorf("no v1 Module in ModuleCapsule")
+	}
 
-	return module, nil
+	return *moduleCapsule.Module, nil
 }

--- a/examples/100-formula-parse/example-formulas.md
+++ b/examples/100-formula-parse/example-formulas.md
@@ -45,13 +45,15 @@ Here's about the simplest formula one could have:
 ```json
 {
 	"formula": {
-		"inputs": {},
-		"action": {
-			"exec": {
-				"command": []
-			}
-		},
-		"outputs": {}
+		"formula.v1": {
+			"inputs": {},
+			"action": {
+				"exec": {
+					"command": []
+				}
+			},
+			"outputs": {}
+		}
 	}
 }
 ```
@@ -80,16 +82,18 @@ Formulas usually have inputs.  And the most common type is a "ware", which will 
 ```json
 {
 	"formula": {
-		"inputs": {
-			"/mount/path": "ware:tar:qwerasdf",
-			"/other/place": "ware:git:abcd1234"
-		},
-		"action": {
-			"exec": {
-				"command": []
-			}
-		},
-		"outputs": {}
+		"formula.v1": {
+			"inputs": {
+				"/mount/path": "ware:tar:qwerasdf",
+				"/other/place": "ware:git:abcd1234"
+			},
+			"action": {
+				"exec": {
+					"command": []
+				}
+			},
+			"outputs": {}
+		}
 	}
 }
 ```
@@ -103,17 +107,19 @@ And in this case, they also are more likely to use a "literal" form.
 ```json
 {
 	"formula": {
-		"inputs": {
-			"$USER": "literal:hello",
-			"$HOME": "literal:/home/hello",
-			"$PATH": "literal:/bin:/usr/bin:/local/bin"
-		},
-		"action": {
-			"exec": {
-				"command": []
-			}
-		},
-		"outputs": {}
+		"formula.v1": {
+			"inputs": {
+				"$USER": "literal:hello",
+				"$HOME": "literal:/home/hello",
+				"$PATH": "literal:/bin:/usr/bin:/local/bin"
+			},
+			"action": {
+				"exec": {
+					"command": []
+				}
+			},
+			"outputs": {}
+		}
 	}
 }
 ```
@@ -135,22 +141,24 @@ Let's show how these values are being parsed.
 ```json
 {
 	"formula": {
-		"inputs": {
-			"$HOME": "literal:/home/hello",
-			"/mount/me": "ware:tar:qwerasdf",
-			"/fancy/stuff": {
-				"basis": "ware:tar:asdfzxcv",
-				"filters": {
-					"demo": "value"
+		"formula.v1": {
+			"inputs": {
+				"$HOME": "literal:/home/hello",
+				"/mount/me": "ware:tar:qwerasdf",
+				"/fancy/stuff": {
+					"basis": "ware:tar:asdfzxcv",
+					"filters": {
+						"demo": "value"
+					}
 				}
-			}
-		},
-		"action": {
-			"exec": {
-				"command": []
-			}
-		},
-		"outputs": {}
+			},
+			"action": {
+				"exec": {
+					"command": []
+				}
+			},
+			"outputs": {}
+		}
 	}
 }
 ```
@@ -161,7 +169,7 @@ and what types we see after parsing the information:
 [testmark]:# (hello-and-debug/formula.debug)
 ```text
 struct<FormulaAndContext>{
-	formula: struct<Formula>{
+	formula: union<FormulaCapsule>{struct<Formula>{
 		inputs: map<Map__SandboxPort__FormulaInput>{
 			union<SandboxPort>{string<SandboxVar>{"HOME"}}: union<FormulaInput>{union<FormulaInputSimple>{string<Literal>{"/home/hello"}}}
 			union<SandboxPort>{string<SandboxPath>{"mount/me"}}: union<FormulaInput>{union<FormulaInputSimple>{struct<WareID>{
@@ -183,7 +191,7 @@ struct<FormulaAndContext>{
 			network: absent
 		}}
 		outputs: map<Map__OutputName__GatherDirective>{}
-	}
+	}}
 	context: absent
 }
 ```
@@ -214,20 +222,22 @@ and a `contents` array. Each element of `contents` will be executed as an indivi
 ```json
 {
 	"formula": {
-		"inputs": {
-			"/mount/path": "ware:tar:qwerasdf",
-			"/other/place": "ware:git:abcd1234"
-		},
-		"action": {
-			"script": {
-				"interpreter": "/bin/sh",
-				"contents": [
-					"echo hello!",
-					"echo this is a script action!"
-				]
-			}
-		},
-		"outputs": {}
+		"formula.v1": {
+			"inputs": {
+				"/mount/path": "ware:tar:qwerasdf",
+				"/other/place": "ware:git:abcd1234"
+			},
+			"action": {
+				"script": {
+					"interpreter": "/bin/sh",
+					"contents": [
+						"echo hello!",
+						"echo this is a script action!"
+					]
+				}
+			},
+			"outputs": {}
+		}
 	}
 }
 ```

--- a/examples/110-formula-usage/example-formula-exec.md
+++ b/examples/110-formula-usage/example-formula-exec.md
@@ -24,15 +24,17 @@ This formula echos a value to stdout.
 ```json
 {
 	"formula": {
-		"inputs": {
-			"/": "ware:tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN"
-		},
-		"action": {
-			"exec": {
-				"command": ["/bin/sh", "-c", "echo hello from warpforge!"]
+		"formula.v1": {
+			"inputs": {
+				"/": "ware:tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN"
+			},
+			"action": {
+				"exec": {
+					"command": ["/bin/sh", "-c", "echo hello from warpforge!"]
+				}
+			},
+			"outputs": {
 			}
-		},
-		"outputs": {
 		}
 	},
 	"context": {
@@ -66,19 +68,21 @@ Note the RunRecord now contains a `results` value which includes the output.
 ```json
 {
 	"formula": {
-		"inputs": {
-			"/": "ware:tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN"
-		},
-		"action": {
-			"exec": {
-				"command": ["/bin/sh", "-c", "mkdir /out; echo hello from warpforge! > /out/test"]
-			}
-		},
-		"outputs": {
-			"test": {
-				"from": "/out",
-				"packtype": "tar"
+		"formula.v1": {
+			"inputs": {
+				"/": "ware:tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN"
 			},
+			"action": {
+				"exec": {
+					"command": ["/bin/sh", "-c", "mkdir /out; echo hello from warpforge! > /out/test"]
+				}
+			},
+			"outputs": {
+				"test": {
+					"from": "/out",
+					"packtype": "tar"
+				},
+			}
 		}
 	},
 	"context": {
@@ -115,16 +119,18 @@ TODO: the mount type is set to `type` here, since mount types currently have no 
 ```json
 {
 	"formula": {
-		"inputs": {
-			"/": "ware:tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN",
-			"/work": "mount:overlay:."
-		},
-		"action": {
-			"exec": {
-				"command": ["/bin/sh", "-c", "ls -al /work"]
+		"formula.v1": {
+			"inputs": {
+				"/": "ware:tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN",
+				"/work": "mount:overlay:."
+			},
+			"action": {
+				"exec": {
+					"command": ["/bin/sh", "-c", "ls -al /work"]
+				}
+			},
+			"outputs": {
 			}
-		},
-		"outputs": {
 		}
 	},
 	"context": {
@@ -157,20 +163,22 @@ This formula uses an input with filters.
 ```json
 {
 	"formula": {
-		"inputs": {
-			"/": {
-				"basis": "ware:tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN",
-				"filters": {
-					"setid": "ignore"
+		"formula.v1": {
+			"inputs": {
+				"/": {
+					"basis": "ware:tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN",
+					"filters": {
+						"setid": "ignore"
+					}
 				}
+			},
+			"action": {
+				"exec": {
+					"command": ["/bin/sh", "-c", "echo hello from warpforge!"]
+				}
+			},
+			"outputs": {
 			}
-		},
-		"action": {
-			"exec": {
-				"command": ["/bin/sh", "-c", "echo hello from warpforge!"]
-			}
-		},
-		"outputs": {
 		}
 	},
 	"context": {
@@ -199,20 +207,22 @@ This formula uses an input with filters.
 ```json
 {
 	"formula": {
-		"inputs": {
-			"/": "ware:tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN",
-			"/mnt/overlay": "mount:overlay:.",
-			"/mnt/ro": "mount:ro:.",
-			"/mnt/rw": "mount:rw:."
-		},
-		"action": {
-			"exec": {
-				"command": ["/bin/sh", "-c", "ls -al /mnt"]
+		"formula.v1": {
+			"inputs": {
+				"/": "ware:tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN",
+				"/mnt/overlay": "mount:overlay:.",
+				"/mnt/ro": "mount:ro:.",
+				"/mnt/rw": "mount:rw:."
+			},
+			"action": {
+				"exec": {
+					"command": ["/bin/sh", "-c", "ls -al /mnt"]
+				}
+			},
+			"outputs": {
 			}
 		},
-		"outputs": {
-		}
-	},
+	}
 	"context": {
 		"warehouses": {
 			"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": "https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"

--- a/examples/110-formula-usage/example-formula-exec.md
+++ b/examples/110-formula-usage/example-formula-exec.md
@@ -38,8 +38,10 @@ This formula echos a value to stdout.
 		}
 	},
 	"context": {
-		"warehouses": {
-			"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": "https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
+		"context.v1": {
+			"warehouses": {
+				"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": "https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
+			}
 		}
 	}
 }
@@ -86,8 +88,10 @@ Note the RunRecord now contains a `results` value which includes the output.
 		}
 	},
 	"context": {
-		"warehouses": {
-			"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": "https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
+		"context.v1": {
+			"warehouses": {
+				"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": "https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
+			}
 		}
 	}
 }
@@ -134,8 +138,10 @@ TODO: the mount type is set to `type` here, since mount types currently have no 
 		}
 	},
 	"context": {
-		"warehouses": {
-			"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": "https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
+		"context.v1": {
+			"warehouses": {
+				"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": "https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
+			}
 		}
 	}
 }
@@ -182,8 +188,10 @@ This formula uses an input with filters.
 		}
 	},
 	"context": {
-		"warehouses": {
-			"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": "https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
+		"context.v1": {
+			"warehouses": {
+				"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": "https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
+			}
 		}
 	}
 }
@@ -224,8 +232,10 @@ This formula uses an input with filters.
 		},
 	}
 	"context": {
-		"warehouses": {
-			"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": "https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
+		"context.v1": {
+			"warehouses": {
+				"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": "https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
+			}
 		}
 	}
 }

--- a/examples/110-formula-usage/example-formula-script.md
+++ b/examples/110-formula-usage/example-formula-script.md
@@ -38,8 +38,10 @@ interpreter (`sh`, `bash`, `zsh`, etc...).
 		}
 	},
 	"context": {
-		"warehouses": {
-			"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": "https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
+		"context.v1": {
+			"warehouses": {
+				"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": "https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
+			}
 		}
 	}
 }

--- a/examples/110-formula-usage/example-formula-script.md
+++ b/examples/110-formula-usage/example-formula-script.md
@@ -14,25 +14,27 @@ interpreter (`sh`, `bash`, `zsh`, etc...).
 ```json
 {
 	"formula": {
-		"inputs": {
-			"/": "ware:tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN"
-		},
-		"action": {
-			"script": {
-				"interpreter": "/bin/sh",
-				"contents": [
-					"MESSAGE='hello, this is a script action'",
-					"echo $MESSAGE",
-					"mkdir /out && echo $MESSAGE > /out/log"
-					"echo done!"
-				]
-			}
-		},
-		"outputs": {
-			"test": {
-				"from": "/out",
-				"packtype": "tar"
+		"formula.v1": {
+			"inputs": {
+				"/": "ware:tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN"
 			},
+			"action": {
+				"script": {
+					"interpreter": "/bin/sh",
+					"contents": [
+						"MESSAGE='hello, this is a script action'",
+						"echo $MESSAGE",
+						"mkdir /out && echo $MESSAGE > /out/log"
+						"echo done!"
+					]
+				}
+			},
+			"outputs": {
+				"test": {
+					"from": "/out",
+					"packtype": "tar"
+				},
+			}
 		}
 	},
 	"context": {

--- a/examples/210-plot-parse/example-plots.md
+++ b/examples/210-plot-parse/example-plots.md
@@ -40,36 +40,38 @@ Here is a relatively simple plot, which has a single step:
 [testmark]:# (simple-plot/plot)
 ```json
 {
-	"inputs": {
-		"thingy": "ware:tar:qwerasdf",
-		"ingest": "ingest:git:.:HEAD"
-	},
-	"steps": {
-		"one": {
-			"protoformula": {
-				"inputs": {
-					"/": "pipe::thingy"
-				},
-				"action": {
-					"exec": {
-						"command": [
-							"/bin/echo",
-							"hi"
-						],
-						"network": false
-					}
-				},
-				"outputs": {
-					"stuff": {
-						"from": "/",
-						"packtype": "tar"
+	"plot.v1": {
+		"inputs": {
+			"thingy": "ware:tar:qwerasdf",
+			"ingest": "ingest:git:.:HEAD"
+		},
+		"steps": {
+			"one": {
+				"protoformula": {
+					"inputs": {
+						"/": "pipe::thingy"
+					},
+					"action": {
+						"exec": {
+							"command": [
+								"/bin/echo",
+								"hi"
+							],
+							"network": false
+						}
+					},
+					"outputs": {
+						"stuff": {
+							"from": "/",
+							"packtype": "tar"
+						}
 					}
 				}
 			}
+		},
+		"outputs": {
+			"test": "pipe:one:stuff"
 		}
-	},
-	"outputs": {
-		"test": "pipe:one:stuff"
 	}
 }
 ```
@@ -88,7 +90,7 @@ The debug dump of this data may be illustrative:
 
 [testmark]:# (simple-plot/plot.debug)
 ```text
-struct<Plot>{
+union<PlotCapsule>{struct<Plot>{
 	inputs: map<Map__LocalLabel__PlotInput>{
 		string<LocalLabel>{"thingy"}: union<PlotInput>{union<PlotInputSimple>{struct<WareID>{
 			packtype: string<Packtype>{"tar"}
@@ -129,7 +131,7 @@ struct<Plot>{
 			label: string<LocalLabel>{"stuff"}
 		}}
 	}
-}
+}}
 ```
 
 This probably seems like a lot of things, compared to a formula.

--- a/examples/220-plot-usage/example-plot-exec.md
+++ b/examples/220-plot-usage/example-plot-exec.md
@@ -23,36 +23,38 @@ This plot has a single protoformula step, which creates a file. This file is use
 [testmark]:# (singlestep/plot)
 ```json
 {
-	"inputs": {
-		"rootfs": "catalog:alpinelinux.org/alpine:v3.15.0:x86_64"
-	},
-	"steps": {
-		"one": {
-			"protoformula": {
-				"inputs": {
-					"/": "pipe::rootfs"
-				},
-				"action": {
-					"exec": {
-						"command": [
-							"/bin/sh",
-							"-c",
-							"echo test > /test"
-						],
-						"network": false
-					}
-				},
-				"outputs": {
-					"test": {
-						"from": "/test",
-						"packtype": "tar"
+	"plot.v1": {
+		"inputs": {
+			"rootfs": "catalog:alpinelinux.org/alpine:v3.15.0:x86_64"
+		},
+		"steps": {
+			"one": {
+				"protoformula": {
+					"inputs": {
+						"/": "pipe::rootfs"
+					},
+					"action": {
+						"exec": {
+							"command": [
+								"/bin/sh",
+								"-c",
+								"echo test > /test"
+							],
+							"network": false
+						}
+					},
+					"outputs": {
+						"test": {
+							"from": "/test",
+							"packtype": "tar"
+						}
 					}
 				}
 			}
+		},
+		"outputs": {
+			"test": "pipe:one:test"
 		}
-	},
-	"outputs": {
-		"test": "pipe:one:test"
 	}
 }
 ```
@@ -82,53 +84,55 @@ The execution order is automatically determined.
 [testmark]:# (multistep/plot)
 ```json
 {
-	"inputs": {
-		"rootfs": "catalog:alpinelinux.org/alpine:v3.15.0:x86_64"
-	},
-	"steps": {
-		"zero": {
-			"protoformula": {
-				"inputs": {
-					"/": "pipe::rootfs"
-				},
-				"action": {
-					"script": {
-						"interpreter": "/bin/sh",
-						"contents": [
-							"mkdir /test",
-							"echo 'hello from step zero' > /test/file"
-						]
-					}
-				},
-				"outputs": {
-					"test": {
-						"from": "/test",
-						"packtype": "tar"
+	"plot.v1": {
+		"inputs": {
+			"rootfs": "catalog:alpinelinux.org/alpine:v3.15.0:x86_64"
+		},
+		"steps": {
+			"zero": {
+				"protoformula": {
+					"inputs": {
+						"/": "pipe::rootfs"
+					},
+					"action": {
+						"script": {
+							"interpreter": "/bin/sh",
+							"contents": [
+								"mkdir /test",
+								"echo 'hello from step zero' > /test/file"
+							]
+						}
+					},
+					"outputs": {
+						"test": {
+							"from": "/test",
+							"packtype": "tar"
+						}
 					}
 				}
+			},
+			"one": {
+				"protoformula": {
+					"inputs": {
+						"/": "pipe::rootfs",
+						"/test": "pipe:zero:test"
+					},
+					"action": {
+						"script": {
+							"interpreter": "/bin/sh",
+							"contents": [
+								"echo 'in step one'",
+								"cat /test/file"
+							]
+						}
+					},
+					"outputs": {}
+				}
 			}
-		},
-		"one": {
-			"protoformula": {
-				"inputs": {
-					"/": "pipe::rootfs",
-					"/test": "pipe:zero:test"
-				},
-				"action": {
-					"script": {
-						"interpreter": "/bin/sh",
-						"contents": [
-							"echo 'in step one'",
-							"cat /test/file"
-						]
-					}
-				},
-				"outputs": {}
-			}
-		}
 
-	},
-	"outputs": {}
+		},
+		"outputs": {}
+	}
 }
 ```
 
@@ -158,88 +162,90 @@ The execution order is computed automatically.
 [testmark]:# (nested/plot)
 ```json
 {
-	"inputs": {
-		"rootfs": "catalog:alpinelinux.org/alpine:v3.15.0:x86_64"
-	},
-	"steps": {
-		"zero-outer": {
-			"plot": {
-				"inputs": {
-					"rootfs": "catalog:alpinelinux.org/alpine:v3.15.0:x86_64"
-				},
-				"steps": {
-					"zero-inner": {
-						"protoformula": {
-							"inputs": {
-								"/": "pipe::rootfs"
-							},
-							"action": {
-								"exec": {
-									"command": [
-										"/bin/sh",
-										"-c",
-										"mkdir /test; echo 'hello from step zero-inner' > /test/file"
-									]
-								}
-							},
-							"outputs": {
-								"test": {
-									"packtype": "tar",
-									"from": "/test"
+	"plot.v1": {
+		"inputs": {
+			"rootfs": "catalog:alpinelinux.org/alpine:v3.15.0:x86_64"
+		},
+		"steps": {
+			"zero-outer": {
+				"plot": {
+					"inputs": {
+						"rootfs": "catalog:alpinelinux.org/alpine:v3.15.0:x86_64"
+					},
+					"steps": {
+						"zero-inner": {
+							"protoformula": {
+								"inputs": {
+									"/": "pipe::rootfs"
+								},
+								"action": {
+									"exec": {
+										"command": [
+											"/bin/sh",
+											"-c",
+											"mkdir /test; echo 'hello from step zero-inner' > /test/file"
+										]
+									}
+								},
+								"outputs": {
+									"test": {
+										"packtype": "tar",
+										"from": "/test"
+									}
 								}
 							}
-						}
-					},
-					"one-inner": {
-						"protoformula": {
-							"inputs": {
-								"/": "pipe::rootfs",
-								"/test": "pipe:zero-inner:test"
-							},
-							"action": {
-								"exec": {
-									"command": [
-										"/bin/sh",
-										"-c",
-										"cat /test/file && echo 'hello from step one-inner' >> /test/file"
-									]
-								}
-							},
-							"outputs": {
-								"test": {
-									"packtype": "tar",
-									"from": "/test"
+						},
+						"one-inner": {
+							"protoformula": {
+								"inputs": {
+									"/": "pipe::rootfs",
+									"/test": "pipe:zero-inner:test"
+								},
+								"action": {
+									"exec": {
+										"command": [
+											"/bin/sh",
+											"-c",
+											"cat /test/file && echo 'hello from step one-inner' >> /test/file"
+										]
+									}
+								},
+								"outputs": {
+									"test": {
+										"packtype": "tar",
+										"from": "/test"
+									}
 								}
 							}
+						},
+					},
+					"outputs": {
+						"test": "pipe:one-inner:test"
+					}
+				}
+			},
+			"one-outer": {
+				"protoformula": {
+					"inputs": {
+						"/": "pipe::rootfs",
+						"/test": "pipe:zero-outer:test"
+					},
+					"action": {
+						"exec": {
+							"command": [
+								"/bin/sh",
+								"-c",
+								"echo 'in one-outer'; cat /test/file"
+							]
 						}
 					},
-				},
-				"outputs": {
-					"test": "pipe:one-inner:test"
+					"outputs": {}
 				}
 			}
 		},
-		"one-outer": {
-			"protoformula": {
-				"inputs": {
-					"/": "pipe::rootfs",
-					"/test": "pipe:zero-outer:test"
-				},
-				"action": {
-					"exec": {
-						"command": [
-							"/bin/sh",
-							"-c",
-							"echo 'in one-outer'; cat /test/file"
-						]
-					}
-				},
-				"outputs": {}
-			}
+		"outputs": {
+			"test": "pipe:zero-outer:test"
 		}
-	},
-	"outputs": {
-		"test": "pipe:zero-outer:test"
 	}
 }
 ```
@@ -269,31 +275,33 @@ the protoformula.
 [testmark]:# (input-types/plot)
 ```json
 {
-	"inputs": {
-		"rootfs": "catalog:alpinelinux.org/alpine:v3.15.0:x86_64",
-		"pwd": "mount:overlay:."
-	},
-	"steps": {
-		"one": {
-			"protoformula": {
-				"inputs": {
-					"/": "pipe::rootfs",
-					"/pwd": "pipe::pwd"
-				},
-				"action": {
-					"exec": {
-						"command": [
-							"/bin/sh",
-							"-c",
-							"ls /pwd"
-						]
-					}
-				},
-				"outputs": {}
+	"plot.v1": {
+		"inputs": {
+			"rootfs": "catalog:alpinelinux.org/alpine:v3.15.0:x86_64",
+			"pwd": "mount:overlay:."
+		},
+		"steps": {
+			"one": {
+				"protoformula": {
+					"inputs": {
+						"/": "pipe::rootfs",
+						"/pwd": "pipe::pwd"
+					},
+					"action": {
+						"exec": {
+							"command": [
+								"/bin/sh",
+								"-c",
+								"ls /pwd"
+							]
+						}
+					},
+					"outputs": {}
+				}
 			}
-		}
-	},
-	"outputs": {}
+		},
+		"outputs": {}
+	}
 }
 ```
 

--- a/examples/500-cli/cli.md
+++ b/examples/500-cli/cli.md
@@ -50,23 +50,27 @@ We'll run this in a filesystem that contains a `formula.json`:
 ```
 {
     "formula": {
-        "inputs": {
-            "/": "ware:tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN"
-        },
-        "action": {
-            "exec": {
-                "command": [
-                    "/bin/sh",
-                    "-c",
-                    "echo hello from warpforge!"
-                ]
-            }
-        },
-        "outputs": {}
+		"formula.v1": {
+			"inputs": {
+				"/": "ware:tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN"
+			},
+			"action": {
+				"exec": {
+					"command": [
+						"/bin/sh",
+						"-c",
+						"echo hello from warpforge!"
+					]
+				}
+			},
+			"outputs": {}
+		}
     },
     "context": {
-		"warehouses": {
-			"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": "https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
+		"context.v1": {
+			"warehouses": {
+				"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": "https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
+			}
 		}
     }
 }
@@ -78,23 +82,27 @@ Together with the verbosity and output formatting flags used above, this will al
 ```
 {
 	"formula": {
-		"inputs": {
-			"/": "ware:tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN"
-		},
-		"action": {
-			"exec": {
-				"command": [
-					"/bin/sh",
-					"-c",
-					"echo hello from warpforge!"
-				]
-			}
-		},
-		"outputs": {}
+		"formula.v1": {
+			"inputs": {
+				"/": "ware:tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN"
+			},
+			"action": {
+				"exec": {
+					"command": [
+						"/bin/sh",
+						"-c",
+						"echo hello from warpforge!"
+					]
+				}
+			},
+			"outputs": {}
+		}
 	},
 	"context": {
-		"warehouses": {
-			"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": "https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
+		"context.v1": {
+			"warehouses": {
+				"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": "https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
+			}
 		}
 	}
 }
@@ -114,7 +122,9 @@ We'll run this in a filesystem that contains a `module.wf` (albeit a pretty sill
 [testmark]:# (checkmodule/fs/module.wf)
 ```
 {
-    "name": "test"
+	"module.v1": {
+		"name": "test"
+	}
 }
 ```
 
@@ -167,23 +177,27 @@ We'll run this in a filesystem that contains a `formula.json`
 ```
 {
     "formula": {
-        "inputs": {
-            "/": "ware:tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN"
-        },
-        "action": {
-            "exec": {
-                "command": [
-                    "/bin/sh",
-                    "-c",
-                    "echo hello from warpforge!"
-                ]
-            }
-        },
-        "outputs": {}
+		"formula.v1": {
+			"inputs": {
+				"/": "ware:tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN"
+			},
+			"action": {
+				"exec": {
+					"command": [
+						"/bin/sh",
+						"-c",
+						"echo hello from warpforge!"
+					]
+				}
+			},
+			"outputs": {}
+		}
     },
     "context": {
-		"warehouses": {
-			"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": "https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
+		"context.v1": {
+			"warehouses": {
+				"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": "https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
+			}
 		}
     }
 }
@@ -216,7 +230,9 @@ A module is declared with two files.  One is the `module.wf` file:
 [testmark]:# (runmodule/fs/module.wf)
 ```
 {
-    "name": "test"
+	"module.v1": {
+		"name": "test"
+	}
 }
 ```
 
@@ -231,88 +247,90 @@ Here's the `plot.wf` file -- this one's a bit bigger and more involved:
 [testmark]:# (runmodule/fs/plot.wf)
 ```
 {
-	"inputs": {
-		"rootfs": "catalog:alpinelinux.org/alpine:v3.15.0:x86_64"
-	},
-	"steps": {
-		"zero-outer": {
-			"plot": {
-				"inputs": {
-					"rootfs": "catalog:alpinelinux.org/alpine:v3.15.0:x86_64"
-				},
-				"steps": {
-					"zero-inner": {
-						"protoformula": {
-							"inputs": {
-								"/": "pipe::rootfs"
-							},
-							"action": {
-								"exec": {
-									"command": [
-										"/bin/sh",
-										"-c",
-										"mkdir /test; echo 'hello from step zero-inner' > /test/file"
-									]
-								}
-							},
-							"outputs": {
-								"test": {
-									"packtype": "tar",
-									"from": "/test"
+	"plot.v1": {
+		"inputs": {
+			"rootfs": "catalog:alpinelinux.org/alpine:v3.15.0:x86_64"
+		},
+		"steps": {
+			"zero-outer": {
+				"plot": {
+					"inputs": {
+						"rootfs": "catalog:alpinelinux.org/alpine:v3.15.0:x86_64"
+					},
+					"steps": {
+						"zero-inner": {
+							"protoformula": {
+								"inputs": {
+									"/": "pipe::rootfs"
+								},
+								"action": {
+									"exec": {
+										"command": [
+											"/bin/sh",
+											"-c",
+											"mkdir /test; echo 'hello from step zero-inner' > /test/file"
+										]
+									}
+								},
+								"outputs": {
+									"test": {
+										"packtype": "tar",
+										"from": "/test"
+									}
 								}
 							}
-						}
-					},
-					"one-inner": {
-						"protoformula": {
-							"inputs": {
-								"/": "pipe::rootfs",
-								"/test": "pipe:zero-inner:test"
-							},
-							"action": {
-								"exec": {
-									"command": [
-										"/bin/sh",
-										"-c",
-										"cat /test/file && echo 'hello from step one-inner' >> /test/file"
-									]
-								}
-							},
-							"outputs": {
-								"test": {
-									"packtype": "tar",
-									"from": "/test"
+						},
+						"one-inner": {
+							"protoformula": {
+								"inputs": {
+									"/": "pipe::rootfs",
+									"/test": "pipe:zero-inner:test"
+								},
+								"action": {
+									"exec": {
+										"command": [
+											"/bin/sh",
+											"-c",
+											"cat /test/file && echo 'hello from step one-inner' >> /test/file"
+										]
+									}
+								},
+								"outputs": {
+									"test": {
+										"packtype": "tar",
+										"from": "/test"
+									}
 								}
 							}
+						},
+					},
+					"outputs": {
+						"test": "pipe:one-inner:test"
+					}
+				}
+			},
+			"one-outer": {
+				"protoformula": {
+					"inputs": {
+						"/": "pipe::rootfs",
+						"/test": "pipe:zero-outer:test"
+					},
+					"action": {
+						"exec": {
+							"command": [
+								"/bin/sh",
+								"-c",
+								"echo 'in one-outer'; cat /test/file"
+							]
 						}
 					},
-				},
-				"outputs": {
-					"test": "pipe:one-inner:test"
+					"outputs": {}
 				}
 			}
 		},
-		"one-outer": {
-			"protoformula": {
-				"inputs": {
-					"/": "pipe::rootfs",
-					"/test": "pipe:zero-outer:test"
-				},
-				"action": {
-					"exec": {
-						"command": [
-							"/bin/sh",
-							"-c",
-							"echo 'in one-outer'; cat /test/file"
-						]
-					}
-				},
-				"outputs": {}
-			}
+		"outputs": {
+			"test": "pipe:zero-outer:test"
 		}
-	},
-	"outputs": {
-		"test": "pipe:zero-outer:test"
 	}
 }
 ```
@@ -327,11 +345,13 @@ a `mirrors.json` file to show where the ware can be fetched.
 [testmark]:# (runmodule/fs/.warpforge/catalog/alpinelinux.org/alpine/module.json)
 ```json
 {
-        "name": "alpinelinux.org/alpine",
-        "releases": {
-                "v3.15.0": "zM5K3WcNp7K5hKapbeaVKZmmTQuN8uhXcvzQSX3AKSEbAtc6QhZHQJLk3ZNeM47Ga81iGdU"
-        },
-        "metadata": {}
+	"catalogmodule.v1": {
+			"name": "alpinelinux.org/alpine",
+			"releases": {
+					"v3.15.0": "zM5K3WcNp7K5hKapbeaVKZmmTQuN8uhXcvzQSX3AKSEbAtc6QhZHQJLk3ZNeM47Ga81iGdU"
+			},
+			"metadata": {}
+	}
 }
 ```
 
@@ -349,11 +369,13 @@ a `mirrors.json` file to show where the ware can be fetched.
 [testmark]:# (runmodule/fs/.warpforge/catalog/alpinelinux.org/alpine/mirrors.json)
 ```json
 {
-    "byWare": {
-        "tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": [
-            "https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
-        ]
-    }
+	"catalogmirrors.v1": {
+		"byWare": {
+			"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": [
+				"https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
+			]
+		}
+	}
 }
 ```
 
@@ -412,11 +434,13 @@ cat .warpforge/catalogs/my-catalog/alpinelinux.org/alpine/mirrors.json
 [testmark]:# (catalog/then-add-tar/then-check/output)
 ```
 {
-	"name": "alpinelinux.org/alpine",
-	"releases": {
-		"v3.15.0": "zM5K3WcNp7K5hKapbeaVKZmmTQuN8uhXcvzQSX3AKSEbAtc6QhZHQJLk3ZNeM47Ga81iGdU"
-	},
-	"metadata": {}
+	"catalogmodule.v1": {
+		"name": "alpinelinux.org/alpine",
+		"releases": {
+			"v3.15.0": "zM5K3WcNp7K5hKapbeaVKZmmTQuN8uhXcvzQSX3AKSEbAtc6QhZHQJLk3ZNeM47Ga81iGdU"
+		},
+		"metadata": {}
+	}
 }
 {
 	"name": "v3.15.0",
@@ -426,10 +450,12 @@ cat .warpforge/catalogs/my-catalog/alpinelinux.org/alpine/mirrors.json
 	"metadata": {}
 }
 {
-	"byWare": {
-		"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": [
-			"https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
-		]
+	"catalogmirrors.v1": {
+		"byWare": {
+			"tar:57j2Ee9HEtDxRLE6uHA1xvmNB2LgqL3HeT5pCXr7EcXkjcoYiGHSBkFyKqQuHFyGPN": [
+				"https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-minirootfs-3.15.0-x86_64.tar.gz"
+			]
+		}
 	}
 }
 ```
@@ -451,11 +477,13 @@ cat .warpforge/catalogs/my-catalog/github.com/githubtraining/training-manual/mir
 [testmark]:# (catalog/then-add-git/then-check/output)
 ```
 {
-	"name": "github.com/githubtraining/training-manual",
-	"releases": {
-		"v1.0": "zM5K3SVi6ptQmHx9cAhq6HefLtMqLLPSoHH5yxqHspgyzrD8p4LQtZ48GMnWk3HqbHPZeA1"
-	},
-	"metadata": {}
+	"catalogmodule.v1": {
+		"name": "github.com/githubtraining/training-manual",
+		"releases": {
+			"v1.0": "zM5K3SVi6ptQmHx9cAhq6HefLtMqLLPSoHH5yxqHspgyzrD8p4LQtZ48GMnWk3HqbHPZeA1"
+		},
+		"metadata": {}
+	}
 }
 {
 	"name": "v1.0",
@@ -465,11 +493,13 @@ cat .warpforge/catalogs/my-catalog/github.com/githubtraining/training-manual/mir
 	"metadata": {}
 }
 {
-	"byModule": {
-		"github.com/githubtraining/training-manual": {
-			"git": [
-				"https://github.com/githubtraining/training-manual"
-			]
+	"catalogmirrors.v1": {
+		"byModule": {
+			"github.com/githubtraining/training-manual": {
+				"git": [
+					"https://github.com/githubtraining/training-manual"
+				]
+			}
 		}
 	}
 }

--- a/pkg/formulaexec/formula_exec.go
+++ b/pkg/formulaexec/formula_exec.go
@@ -584,7 +584,11 @@ func execFormula(ws *workspace.Workspace, fc wfapi.FormulaAndContext, formulaCon
 		return rr, wfapi.ErrorFormulaInvalid("FormulaCapsule does not contain a v1 formula")
 	}
 	formula := fc.Formula.Formula
-	context := fc.Context
+
+	context := wfapi.FormulaContext{}
+	if fc.Context != nil && fc.Context.FormulaContext != nil {
+		context = *fc.Context.FormulaContext
+	}
 
 	// convert formula to node
 	nFormula := bindnode.Wrap(fc.Formula.Formula, wfapi.TypeSystem.TypeByName("Formula"))
@@ -785,7 +789,7 @@ func execFormula(ws *workspace.Workspace, fc wfapi.FormulaAndContext, formulaCon
 					color.WhiteString(inputSimple.WareID.String()),
 					color.HiBlueString("destPath"),
 					color.WhiteString(destPath))
-				mnt, err = makeWareMount(config, *inputSimple.WareID, destPath, context, filters, logger)
+				mnt, err = makeWareMount(config, *inputSimple.WareID, destPath, &context, filters, logger)
 				if err != nil {
 					return rr, err
 				}

--- a/pkg/formulaexec/formula_exec.go
+++ b/pkg/formulaexec/formula_exec.go
@@ -581,7 +581,7 @@ func execFormula(ws *workspace.Workspace, fc wfapi.FormulaAndContext, formulaCon
 	rr := wfapi.RunRecord{}
 
 	if fc.Formula.Formula == nil {
-		return rr, wfapi.ErrorFormulaInvalid("FormulaCapsule does not contain a v1 formula")
+		return rr, wfapi.ErrorFormulaInvalid("no v1 Formula in FormulaCapsule")
 	}
 	formula := fc.Formula.Formula
 

--- a/pkg/plotexec/plot_exec.go
+++ b/pkg/plotexec/plot_exec.go
@@ -344,7 +344,7 @@ func execProtoformula(wsSet workspace.WorkspaceSet,
 	rr, err := formulaexec.Exec(wsSet.Root,
 		wfapi.FormulaAndContext{
 			Formula: wfapi.FormulaCapsule{Formula: &formula},
-			Context: &ctx,
+			Context: &wfapi.FormulaContextCapsule{FormulaContext: &ctx},
 		},
 		config.FormulaExecConfig,
 		logger)

--- a/pkg/plotexec/plot_exec.go
+++ b/pkg/plotexec/plot_exec.go
@@ -197,7 +197,7 @@ func plotInputToFormulaInputSimple(wsSet workspace.WorkspaceSet,
 					}
 					logger.Info(LOG_TAG, "resolving replay for module = %s, release = %s...",
 						basis.CatalogRef.ModuleName, basis.CatalogRef.ReleaseName)
-					result, err := Exec(wsSet, *replay, config, logger)
+					result, err := execPlot(wsSet, *replay, config, logger)
 					if err != nil {
 						return wfapi.FormulaInputSimple{}, nil, wfapi.ErrorPlotStepFailed("replay", err)
 					}
@@ -343,7 +343,7 @@ func execProtoformula(wsSet workspace.WorkspaceSet,
 	// execute the derived formula
 	rr, err := formulaexec.Exec(wsSet.Root,
 		wfapi.FormulaAndContext{
-			Formula: formula,
+			Formula: wfapi.FormulaCapsule{Formula: &formula},
 			Context: &ctx,
 		},
 		config.FormulaExecConfig,
@@ -352,6 +352,7 @@ func execProtoformula(wsSet workspace.WorkspaceSet,
 }
 
 // Execute a Plot using the provided WorkspaceSet
+// This is an internal function which takes a V1 plot and is called recursively
 //
 // Errors:
 //
@@ -362,7 +363,7 @@ func execProtoformula(wsSet workspace.WorkspaceSet,
 //    - warpforge-error-catalog-parse -- when parsing of catalog files fails
 //    - warpforge-error-catalog-invalid -- when the catalog contains invalid data
 //    - warpforge-error-plot-step-failed -- when execution of a plot step fails
-func Exec(wsSet workspace.WorkspaceSet, plot wfapi.Plot, config wfapi.PlotExecConfig, logger logging.Logger) (wfapi.PlotResults, error) {
+func execPlot(wsSet workspace.WorkspaceSet, plot wfapi.Plot, config wfapi.PlotExecConfig, logger logging.Logger) (wfapi.PlotResults, error) {
 	pipeCtx := make(pipeMap)
 	results := wfapi.PlotResults{}
 
@@ -430,7 +431,7 @@ func Exec(wsSet workspace.WorkspaceSet, plot wfapi.Plot, config wfapi.PlotExecCo
 				color.WhiteString("evaluating subplot"),
 			)
 
-			stepResults, err := Exec(wsSet, *step.Plot, config, logger)
+			stepResults, err := execPlot(wsSet, *step.Plot, config, logger)
 			if err != nil {
 				return results, wfapi.ErrorPlotStepFailed(name, err)
 			}
@@ -475,4 +476,22 @@ func Exec(wsSet workspace.WorkspaceSet, plot wfapi.Plot, config wfapi.PlotExecCo
 
 	logger.Info(LOG_TAG_END, "")
 	return results, nil
+}
+
+// Execute a PlotCapsule using the provided WorkspaceSet
+//
+// Errors:
+//
+//    - warpforge-error-plot-invalid -- when the provided plot input is invalid
+//    - warpforge-error-missing-catalog-entry -- when a referenced catalog reference cannot be found
+//    - warpforge-error-git -- when a git related error occurs during a git ingest
+//    - warpforge-error-io -- when an IO error occurs during conversion
+//    - warpforge-error-catalog-parse -- when parsing of catalog files fails
+//    - warpforge-error-catalog-invalid -- when the catalog contains invalid data
+//    - warpforge-error-plot-step-failed -- when execution of a plot step fails
+func Exec(wsSet workspace.WorkspaceSet, plotCapsule wfapi.PlotCapsule, config wfapi.PlotExecConfig, logger logging.Logger) (wfapi.PlotResults, error) {
+	if plotCapsule.Plot == nil {
+		return wfapi.PlotResults{}, wfapi.ErrorPlotInvalid("PlotCapsule does not contain a v1 plot")
+	}
+	return execPlot(wsSet, *plotCapsule.Plot, config, logger)
 }

--- a/pkg/plotexec/plot_exec_test.go
+++ b/pkg/plotexec/plot_exec_test.go
@@ -56,12 +56,13 @@ func TestFormulaExecFixtures(t *testing.T) {
 				serial := dir.Children["plot"].Hunk.Body
 
 				t.Run("exec-plot", func(t *testing.T) {
-					plot := wfapi.Plot{}
-					_, err := ipld.Unmarshal(serial, json.Decode, &plot, wfapi.TypeSystem.TypeByName("Plot"))
+					plotCapsule := wfapi.PlotCapsule{}
+					_, err := ipld.Unmarshal(serial, json.Decode, &plotCapsule, wfapi.TypeSystem.TypeByName("PlotCapsule"))
 					qt.Assert(t, err, qt.IsNil)
+					qt.Assert(t, plotCapsule.Plot, qt.IsNotNil)
 
 					// determine step ordering and compare to example
-					steps, err := OrderStepsAll(plot)
+					steps, err := OrderStepsAll(*plotCapsule.Plot)
 					qt.Assert(t, err, qt.IsNil)
 					if dir.Children["order"] != nil {
 						qt.Assert(t, string(dir.Children["order"].Hunk.Body), qt.CmpEquals(), fmt.Sprintf("%s\n", steps))
@@ -71,7 +72,7 @@ func TestFormulaExecFixtures(t *testing.T) {
 					config := wfapi.PlotExecConfig{
 						Recursive: true,
 					}
-					results, err := Exec(wss, plot, config, logging.DefaultLogger())
+					results, err := Exec(wss, plotCapsule, config, logging.DefaultLogger())
 					qt.Assert(t, err, qt.IsNil)
 
 					// print the serialized results, this can be copied into the testmark file

--- a/pkg/workspace/catalog.go
+++ b/pkg/workspace/catalog.go
@@ -305,7 +305,7 @@ func (cat *Catalog) GetModule(ref wfapi.CatalogRef) (*wfapi.CatalogModule, wfapi
 		return nil, wfapi.ErrorCatalogParse(modPath, err)
 	}
 	if modCapsule.CatalogModule == nil {
-		return nil, wfapi.ErrorCatalogParse(modPath, fmt.Errorf("no v1 CatalogModule found"))
+		return nil, wfapi.ErrorCatalogParse(modPath, fmt.Errorf("no v1 CatalogModule in CatalogModuleCapsule"))
 	}
 
 	return modCapsule.CatalogModule, nil
@@ -471,7 +471,7 @@ func (cat *Catalog) AddByWareMirror(
 			return wfapi.ErrorCatalogParse(mirrorsPath, err)
 		}
 		if mirrorsCapsule.CatalogMirrors == nil {
-			return wfapi.ErrorCatalogParse(mirrorsPath, fmt.Errorf("no v1 CatalogMirrors in capsule"))
+			return wfapi.ErrorCatalogParse(mirrorsPath, fmt.Errorf("no v1 CatalogMirrors in CatalogMirrorsCapsule"))
 		}
 	} else {
 		return wfapi.ErrorIo("could not open mirrors file", &mirrorsPath, err)

--- a/pkg/workspace/catalog.go
+++ b/pkg/workspace/catalog.go
@@ -416,7 +416,7 @@ func (cat *Catalog) AddItem(
 
 	// serialize the updated structures
 	modCapsule := wfapi.CatalogModuleCapsule{CatalogModule: module}
-	moduleSerial, errRaw := ipld.Marshal(json.Encode, modCapsule, wfapi.TypeSystem.TypeByName("CatalogModuleCapsule"))
+	moduleSerial, errRaw := ipld.Marshal(json.Encode, &modCapsule, wfapi.TypeSystem.TypeByName("CatalogModuleCapsule"))
 	if errRaw != nil {
 		return wfapi.ErrorSerialization("failed to serialize module", errRaw)
 	}
@@ -510,7 +510,7 @@ func (cat *Catalog) AddByWareMirror(
 	if err != nil {
 		return wfapi.ErrorIo("could not create catalog path", &path, err)
 	}
-	mirrorSerial, err := ipld.Marshal(json.Encode, &mirrors, wfapi.TypeSystem.TypeByName("CatalogMirrorsCapsule"))
+	mirrorSerial, err := ipld.Marshal(json.Encode, &mirrorsCapsule, wfapi.TypeSystem.TypeByName("CatalogMirrorsCapsule"))
 	if err != nil {
 		return wfapi.ErrorSerialization("could not serialize mirror", err)
 	}

--- a/pkg/workspace/catalog_test.go
+++ b/pkg/workspace/catalog_test.go
@@ -11,11 +11,13 @@ import (
 func TestCatalogLookup(t *testing.T) {
 	t.Run("catalog-lookup", func(t *testing.T) {
 		moduleData := `{
-	"name": "example.com/module",
-	"metadata": {},
-	"releases": {
-		"v1.0": "zM5K3YdpMrp1z7Zs2yMQbmRxndxeCbk7LeCqRzgBcC64JTLNSyGnJtwUdim94mddgbFNw2s"
-	} 
+	"catalogmodule.v1": {
+		"name": "example.com/module",
+		"metadata": {},
+		"releases": {
+			"v1.0": "zM5K3YdpMrp1z7Zs2yMQbmRxndxeCbk7LeCqRzgBcC64JTLNSyGnJtwUdim94mddgbFNw2s"
+		} 
+	}
 }
 `
 		releaseData := `{
@@ -29,44 +31,48 @@ func TestCatalogLookup(t *testing.T) {
 }
 `
 		mirrorData := `{
-	"byWare": {
-		"tar:abcd": [
-			"https://example.com/module/module-v1.0-x86_64.tgz"
-		]
+	"catalogmirrors.v1": {
+		"byWare": {
+			"tar:abcd": [
+				"https://example.com/module/module-v1.0-x86_64.tgz"
+			]
+		}
 	}
 }
 `
 		replayData := `{
-	"inputs": {
-			"rootfs": "catalog:alpinelinux.org/alpine:v3.15.0:x86_64"
-	},
-	"steps": {
-			"hello-world": {
-					"protoformula": {
-							"inputs": {
-									"/": "pipe::rootfs"
-							},
-							"action": {
-									"script": {
-											"interpreter": "/bin/sh",
-											"contents": [
-													"mkdir /output",
-													"echo 'hello world' | tee /output/file"
-											],
-											"network": false
-									}
-							},
-							"outputs": {
-									"out": {
-											"from": "/output",
-											"packtype": "tar"
-									}
-							}
-					}
-			}
-	},
-	"outputs": {
-			"output": "pipe:hello-world:out"
+	"plot.v1": {
+		"inputs": {
+				"rootfs": "catalog:alpinelinux.org/alpine:v3.15.0:x86_64"
+		},
+		"steps": {
+				"hello-world": {
+						"protoformula": {
+								"inputs": {
+										"/": "pipe::rootfs"
+								},
+								"action": {
+										"script": {
+												"interpreter": "/bin/sh",
+												"contents": [
+														"mkdir /output",
+														"echo 'hello world' | tee /output/file"
+												],
+												"network": false
+										}
+								},
+								"outputs": {
+										"out": {
+												"from": "/output",
+												"packtype": "tar"
+										}
+								}
+						}
+				}
+		},
+		"outputs": {
+				"output": "pipe:hello-world:out"
+		}
 	}
 }
 `

--- a/pkg/workspace/catalog_test.go
+++ b/pkg/workspace/catalog_test.go
@@ -16,7 +16,7 @@ func TestCatalogLookup(t *testing.T) {
 		"metadata": {},
 		"releases": {
 			"v1.0": "zM5K3YdpMrp1z7Zs2yMQbmRxndxeCbk7LeCqRzgBcC64JTLNSyGnJtwUdim94mddgbFNw2s"
-		} 
+		}
 	}
 }
 `

--- a/wfapi/catalog.go
+++ b/wfapi/catalog.go
@@ -9,10 +9,6 @@ import (
 	"github.com/ipld/go-ipld-prime/schema"
 )
 
-type CatalogLineageEnvelope struct {
-	CatalogLineage *CatalogLineage
-}
-
 type CatalogLineage struct {
 	Name     string
 	Metadata struct {
@@ -22,16 +18,12 @@ type CatalogLineage struct {
 	Releases []CatalogRelease
 }
 
-type CatalogMirrorEnvelope struct {
-	CatalogMirror *CatalogMirror
-}
-
-type CatalogMirrorByWare struct {
+type CatalogMirrorsByWare struct {
 	Keys   []WareID
 	Values map[WareID][]WarehouseAddr
 }
 
-type CatalogMirrorByModule struct {
+type CatalogMirrorsByModule struct {
 	Keys   []ModuleName
 	Values map[ModuleName]CatalogMirrorsByPacktype
 }
@@ -41,18 +33,24 @@ type CatalogMirrorsByPacktype struct {
 	Values map[Packtype][]WarehouseAddr
 }
 
-type CatalogMirror struct {
-	ByWare   *CatalogMirrorByWare
-	ByModule *CatalogMirrorByModule
+type CatalogMirrorsCapsule struct {
+	CatalogMirrors *CatalogMirrors
 }
 
-// NEW CATALOG TYPES
+type CatalogMirrors struct {
+	ByWare   *CatalogMirrorsByWare
+	ByModule *CatalogMirrorsByModule
+}
 
 type CatalogReleaseCID string
 
 type Catalog struct {
 	Keys   []ModuleName
 	Values map[ModuleName]CatalogModule
+}
+
+type CatalogModuleCapsule struct {
+	CatalogModule *CatalogModule
 }
 
 type CatalogModule struct {
@@ -100,4 +98,8 @@ func (rel *CatalogRelease) Cid() CatalogReleaseCID {
 		panic(fmt.Sprintf("Fatal IPLD Error: failed to encode CID for CatalogRelease: %s", errRaw))
 	}
 	return CatalogReleaseCID(cid)
+}
+
+type ReplayCapsule struct {
+	Plot *Plot
 }

--- a/wfapi/formula.go
+++ b/wfapi/formula.go
@@ -84,6 +84,10 @@ type Action_Script struct {
 	Network     *bool
 }
 
+type FormulaContextCapsule struct {
+	FormulaContext *FormulaContext
+}
+
 type FormulaContext struct {
 	Warehouses struct {
 		Keys   []WareID
@@ -93,7 +97,7 @@ type FormulaContext struct {
 
 type FormulaAndContext struct {
 	Formula FormulaCapsule
-	Context *FormulaContext
+	Context *FormulaContextCapsule
 }
 
 type RunRecord struct {

--- a/wfapi/formula.go
+++ b/wfapi/formula.go
@@ -1,5 +1,9 @@
 package wfapi
 
+type FormulaCapsule struct {
+	Formula *Formula
+}
+
 type Formula struct {
 	Inputs struct {
 		Keys   []SandboxPort
@@ -88,7 +92,7 @@ type FormulaContext struct {
 }
 
 type FormulaAndContext struct {
-	Formula Formula
+	Formula FormulaCapsule
 	Context *FormulaContext
 }
 

--- a/wfapi/formula_spec_test.go
+++ b/wfapi/formula_spec_test.go
@@ -58,7 +58,8 @@ func TestFormulaParseFixtures(t *testing.T) {
 					// (Also encodes, implicitly.  So will probably fail if the above was broken.)
 					// Path into the Formula before doing this -- we don't want to hash the context or the envelope type.
 					if dir.Children["cid"] != nil {
-						nFormula, _ := n.LookupByString("formula")
+						nCapsule, _ := n.LookupByString("formula")
+						nFormula, _ := nCapsule.LookupByString("Formula")
 						lsys := cidlink.DefaultLinkSystem()
 						lnk, err := lsys.ComputeLink(cidlink.LinkPrototype{cid.Prefix{
 							Version:  1,    // Usually '1'.

--- a/wfapi/formula_test.go
+++ b/wfapi/formula_test.go
@@ -58,7 +58,7 @@ func TestParseFormulaAndContext(t *testing.T) {
 		SandboxPort{SandboxVar: func() *SandboxVar { v := SandboxVar("ENV_VAR"); return &v }()},
 		SandboxPort{SandboxPath: func() *SandboxPath { v := SandboxPath("more/mounts"); return &v }()},
 	}
-	inputs := frmAndCtx.Formula.Inputs
+	inputs := frmAndCtx.Formula.Formula.Inputs
 	qt.Assert(t, inputs.Keys, qt.DeepEquals, ports)
 	// Okay, this is going to look a little funny, and it's because we've got another upstream bug to fix.
 	// `inputs.Values[ports[0]]` isn't enough ... because SandboxPort has pointers in it... so, key equality fail.

--- a/wfapi/formula_test.go
+++ b/wfapi/formula_test.go
@@ -11,39 +11,43 @@ import (
 func TestParseFormulaAndContext(t *testing.T) {
 	serial := `{
 	"formula": {
-		"inputs": {
-			"/mount/path": "ware:tar:qwerasdf",
-			"$ENV_VAR": "literal:hello",
-			"/more/mounts": {
-				"basis": "ware:tar:fghjkl",
-				"filters": {
-					"uid": "10"
+		"formula.v1": {
+			"inputs": {
+				"/mount/path": "ware:tar:qwerasdf",
+				"$ENV_VAR": "literal:hello",
+				"/more/mounts": {
+					"basis": "ware:tar:fghjkl",
+					"filters": {
+						"uid": "10"
+					}
 				}
-			}
-		},
-		"action": {
-			"exec": {
-				"command": [
-					"/bin/bash",
-					"-c",
-					"echo hey there"
-				]
-			}
-		},
-		"outputs": {
-			"theoutputlabel": {
-				"from": "/collect/here",
-				"packtype": "tar"
 			},
-			"another": {
-				"from": "$VAR"
+			"action": {
+				"exec": {
+					"command": [
+						"/bin/bash",
+						"-c",
+						"echo hey there"
+					]
+				}
+			},
+			"outputs": {
+				"theoutputlabel": {
+					"from": "/collect/here",
+					"packtype": "tar"
+				},
+				"another": {
+					"from": "$VAR"
+				}
 			}
 		}
 	},
 	"context": {
-		"warehouses": {
-			"tar:qwerasdf": "ca+file:///somewhere/",
-			"tar:fghjkl": "ca+file:///elsewhere/"
+		"context.v1": {
+			"warehouses": {
+				"tar:qwerasdf": "ca+file:///somewhere/",
+				"tar:fghjkl": "ca+file:///elsewhere/"
+			}
 		}
 	}
 }

--- a/wfapi/module.go
+++ b/wfapi/module.go
@@ -1,5 +1,9 @@
 package wfapi
 
+type ModuleCapsule struct {
+	Module *Module
+}
+
 type Module struct {
 	// name might go here?  other config?  unsure honestly, mostly leaving space for future expansion.
 	Name ModuleName

--- a/wfapi/plot.go
+++ b/wfapi/plot.go
@@ -11,6 +11,10 @@ import (
 
 type PlotCID string
 
+type PlotCapsule struct {
+	Plot *Plot
+}
+
 type Plot struct {
 	Inputs struct {
 		Keys   []LocalLabel

--- a/wfapi/plot_spec_test.go
+++ b/wfapi/plot_spec_test.go
@@ -29,8 +29,8 @@ func TestPlotParseFixtures(t *testing.T) {
 
 				// Unmarshal.  Assert it works.
 				t.Run("unmarshal", func(t *testing.T) {
-					plot := Plot{}
-					n, err := ipld.Unmarshal(serial, json.Decode, &plot, TypeSystem.TypeByName("Plot"))
+					plotCapsule := PlotCapsule{}
+					n, err := ipld.Unmarshal(serial, json.Decode, &plotCapsule, TypeSystem.TypeByName("PlotCapsule"))
 					qt.Assert(t, err, qt.IsNil)
 
 					// If there was data about debug forms, check that matches.
@@ -41,7 +41,7 @@ func TestPlotParseFixtures(t *testing.T) {
 
 					// Remarshal.  Assert it works.
 					t.Run("remarshal", func(t *testing.T) {
-						reserial, err := ipld.Marshal(json.Encode, &plot, TypeSystem.TypeByName("Plot"))
+						reserial, err := ipld.Marshal(json.Encode, &plotCapsule, TypeSystem.TypeByName("PlotCapsule"))
 						qt.Assert(t, err, qt.IsNil)
 
 						// And assert it's string equal.

--- a/wfapi/wfapi.ipldsch
+++ b/wfapi/wfapi.ipldsch
@@ -185,8 +185,12 @@ type WarehouseAddr string
 # when parsing a formula file.
 type FormulaAndContext struct {
 	formula FormulaCapsule
-	context optional FormulaContext
+	context optional FormulaContextCapsule
 }
+
+type FormulaContextCapsule union {
+	| FormulaContext "context.v1"
+} representation keyed
 
 type FormulaContext struct {
 	warehouses {WareID:WarehouseAddr}

--- a/wfapi/wfapi.ipldsch
+++ b/wfapi/wfapi.ipldsch
@@ -29,6 +29,11 @@ type Packtype string
 # The Layer 1 API consists of the things we need to do execution. This provides
 # the minimal set of features needed to define inputs, an action, and outputs.
 
+# FormulaCapsule wraps the Formula to allow for new versions in the future
+type FormulaCapsule union {
+	| Formula "formula.v1"
+} representation keyed
+
 # Formula describes a single computation. 
 # What exactly the computation is is defined by the action
 # (of which there are several kinds, but typically, it's commands
@@ -179,7 +184,7 @@ type WarehouseAddr string
 # FormulaAndContext is what we actually use as the document root
 # when parsing a formula file.
 type FormulaAndContext struct {
-	formula Formula
+	formula FormulaCapsule
 	context optional FormulaContext
 }
 
@@ -209,6 +214,11 @@ type ApiOutput union {
 
 # Layer 2
 
+type ModuleCapsule union {
+	| Module "module.v1"
+} representation keyed
+
+
 type Module struct {
 	name ModuleName
 	# semantically: "plot optional Plot"... but practically: it's in a sibling file.
@@ -222,6 +232,10 @@ type Module struct {
 # Characters like "/" and "." are allowed, but ":" and whitespace is forbidden
 # and the use of other punctuation characters is Not Recommended.
 type ModuleName string
+
+type PlotCapsule union {
+	| Plot "plot.v1"
+} representation keyed
 
 type Plot struct { # has previously had many names: protoformula, module, etc.
 	inputs {LocalLabel:PlotInput}
@@ -321,6 +335,10 @@ type CatalogRef struct {
 	join ":"
 }
 
+type CatalogModuleCapsule union {
+	| CatalogModule "catalogmodule.v1"
+} representation keyed
+
 type CatalogModule struct {
 	name ModuleName
 	releases {ReleaseName:CatalogReleaseCID}
@@ -337,13 +355,21 @@ type ItemLabel string
 type ReleaseName string
 type CatalogReleaseCID string
 
-type CatalogMirror union {
-	| CatalogMirrorByWare "byWare"
-	| CatalogMirrorByModule "byModule"
+type CatalogMirrorsCapsule union {
+	| CatalogMirrors "catalogmirrors.v1"
+} representation keyed
+
+type CatalogMirrors union {
+	| CatalogMirrorsByWare "byWare"
+	| CatalogMirrorsByModule "byModule"
 } representation keyed
 
 type WarehouseAddrList [WarehouseAddr]
 
-type CatalogMirrorByWare {WareID:WarehouseAddrList}
-type CatalogMirrorByModule {ModuleName:CatalogMirrorsByPacktype}
+type CatalogMirrorsByWare {WareID:WarehouseAddrList}
+type CatalogMirrorsByModule {ModuleName:CatalogMirrorsByPacktype}
 type CatalogMirrorsByPacktype {Packtype:WarehouseAddrList}
+
+type ReplayCapsule union {
+	| Plot "plot.v1"
+} representation keyed


### PR DESCRIPTION
Add "Capsule" types for various types in wfapi. These Capsules allow us to version the type by using an IPLD union, and create breaking changes in the future without losing backwards compatibility. This also fixes all tests and other code which now needs to support the Capsule types.