### PR TITLE
Fix runpath being overridden

### DIFF
--- a/pkg/formulaexec/formula_exec.go
+++ b/pkg/formulaexec/formula_exec.go
@@ -672,7 +672,7 @@ func execFormula(ws *workspace.Workspace, fc wfapi.FormulaAndContext, formulaCon
 		base = os.TempDir()
 	}
 	runPath, errRaw := ioutil.TempDir(base, "warpforge-run-")
-	if err != nil {
+	if errRaw != nil {
 		return rr, wfapi.ErrorIo("failed to create temp run directory", nil, errRaw)
 	}
 


### PR DESCRIPTION
Fixes silent overriding of the run path to an empty string
when temp dir creation failed.
