### PR TITLE
Workaround for terminal echo lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ else
 	$(SERUM) -strict ./...
 endif
 	go test ./...
+	@stty sane
 
 all: test install
 


### PR DESCRIPTION
Adding stty sane after tests should reset the terminal echo settings and
anything else that may have been inadvertently corrupted. This should help
reduce the loss in productivity caused by this problem, however we would
like to find the root cause before it becomes an issue for users.