### PR TITLE
fix trace shutdown calls to prevent nil pointer deref

### DIFF
--- a/cmd/warpforge/catalog.go
+++ b/cmd/warpforge/catalog.go
@@ -470,7 +470,7 @@ func cmdCatalogRelease(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("could not initialize tracing: %w", err)
 	}
-	defer traceProvider.Shutdown(c.Context)
+	defer traceShutdown(c.Context, traceProvider)
 	tr := otel.Tracer(TRACER_NAME)
 	ctx, span := tr.Start(ctx, c.Command.FullName())
 	defer span.End()

--- a/cmd/warpforge/watch.go
+++ b/cmd/warpforge/watch.go
@@ -32,7 +32,7 @@ func cmdWatch(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("could not initialize tracing: %w", err)
 	}
-	defer traceProvider.Shutdown(c.Context)
+	defer traceShutdown(c.Context, traceProvider)
 	tr := otel.Tracer(TRACER_NAME)
 	ctx, span := tr.Start(ctx, c.Command.FullName())
 	defer span.End()


### PR DESCRIPTION
Minor fix to prevent nil pointer deref when `--trace` is not set.