### PR TITLE
Extracting filesystem accesses; 'workspace inspect' command

### DIFF
--- a/cmd/warpforge/catalog.go
+++ b/cmd/warpforge/catalog.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -329,6 +330,7 @@ func cmdCatalogBundle(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get pwd: %s", err)
 	}
+	pwd = pwd[1:] // Drop leading slash, for use with fs package.
 
 	plot, err := dab.PlotFromFile(fsys, filepath.Join(pwd, dab.MagicFilename_Plot))
 	if err != nil {
@@ -339,8 +341,8 @@ func cmdCatalogBundle(c *cli.Context) error {
 
 	catalogPath := filepath.Join(pwd, ".warpforge", "catalog")
 	// create a catalog if it does not exist
-	if _, err = os.Stat(catalogPath); os.IsNotExist(err) {
-		err = os.MkdirAll(catalogPath, 0755)
+	if _, err = fs.Stat(fsys, catalogPath); os.IsNotExist(err) {
+		err = os.MkdirAll("/"+catalogPath, 0755)
 		if err != nil {
 			return fmt.Errorf("failed to create catalog directory: %s", err)
 		}

--- a/cmd/warpforge/check.go
+++ b/cmd/warpforge/check.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/json"
 	"github.com/urfave/cli/v2"
+
 	"github.com/warpfork/warpforge/pkg/plotexec"
 	"github.com/warpfork/warpforge/wfapi"
 )

--- a/cmd/warpforge/ferk.go
+++ b/cmd/warpforge/ferk.go
@@ -8,10 +8,12 @@ import (
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/json"
 	"github.com/urfave/cli/v2"
+	"go.opentelemetry.io/otel"
+
+	"github.com/warpfork/warpforge/pkg/dab"
 	"github.com/warpfork/warpforge/pkg/logging"
 	"github.com/warpfork/warpforge/pkg/plotexec"
 	"github.com/warpfork/warpforge/wfapi"
-	"go.opentelemetry.io/otel"
 )
 
 var ferkCmdDef = cli.Command{
@@ -89,7 +91,9 @@ func cmdFerk(c *cli.Context) error {
 	ctx, span := tr.Start(ctx, c.Command.FullName())
 	defer span.End()
 
-	wss, err := openWorkspaceSet()
+	fsys := os.DirFS("/")
+
+	wss, err := openWorkspaceSet(fsys)
 	if err != nil {
 		return err
 	}
@@ -97,7 +101,7 @@ func cmdFerk(c *cli.Context) error {
 	plot := wfapi.Plot{}
 	if c.String("plot") != "" {
 		// plot was provided, load from file
-		plot, err = plotFromFile(c.String("plot"))
+		plot, err = dab.PlotFromFile(fsys, c.String("plot"))
 		if err != nil {
 			return fmt.Errorf("error loading plot from file %q: %s", c.String("plot"), err)
 		}

--- a/cmd/warpforge/main.go
+++ b/cmd/warpforge/main.go
@@ -59,6 +59,13 @@ func makeApp(stdin io.Reader, stdout, stderr io.Writer) *cli.App {
 		&statusCmdDef,
 		&quickstartCmdDef,
 		&ferkCmdDef,
+		&cli.Command{
+			Name:  "workspace",
+			Usage: "Grouping for subcommands that inspect or affect a whole workspace.",
+			Subcommands: []*cli.Command{
+				&cmdDefWorkspaceInspect,
+			},
+		},
 	}
 	return app
 }

--- a/cmd/warpforge/main_test.go
+++ b/cmd/warpforge/main_test.go
@@ -11,6 +11,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/warpfork/go-testmark"
 	"github.com/warpfork/go-testmark/testexec"
+
 	"github.com/warpfork/warpforge/pkg/workspace"
 )
 

--- a/cmd/warpforge/quickstart.go
+++ b/cmd/warpforge/quickstart.go
@@ -7,6 +7,8 @@ import (
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/json"
 	"github.com/urfave/cli/v2"
+
+	"github.com/warpfork/warpforge/pkg/dab"
 	"github.com/warpfork/warpforge/wfapi"
 )
 
@@ -59,13 +61,13 @@ func cmdQuickstart(c *cli.Context) error {
 		return fmt.Errorf("no module name provided")
 	}
 
-	_, err := os.Stat(MODULE_FILE_NAME)
+	_, err := os.Stat(dab.MagicFilename_Module)
 	if !os.IsNotExist(err) {
-		return fmt.Errorf("%s file already exists", MODULE_FILE_NAME)
+		return fmt.Errorf("%s file already exists", dab.MagicFilename_Module)
 	}
-	_, err = os.Stat(PLOT_FILE_NAME)
+	_, err = os.Stat(dab.MagicFilename_Plot)
 	if !os.IsNotExist(err) {
-		return fmt.Errorf("%s file already exists", PLOT_FILE_NAME)
+		return fmt.Errorf("%s file already exists", dab.MagicFilename_Plot)
 	}
 
 	moduleName := c.Args().First()
@@ -79,7 +81,7 @@ func cmdQuickstart(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to serialize module")
 	}
-	err = os.WriteFile(MODULE_FILE_NAME, moduleSerial, 0644)
+	err = os.WriteFile(dab.MagicFilename_Module, moduleSerial, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to write module.json file: %s", err)
 	}
@@ -94,17 +96,17 @@ func cmdQuickstart(c *cli.Context) error {
 		return fmt.Errorf("failed to serialize plot")
 	}
 
-	err = os.WriteFile(PLOT_FILE_NAME, plotSerial, 0644)
+	err = os.WriteFile(dab.MagicFilename_Plot, plotSerial, 0644)
 	if err != nil {
-		return fmt.Errorf("failed to write %s: %s", PLOT_FILE_NAME, err)
+		return fmt.Errorf("failed to write %s: %s", dab.MagicFilename_Plot, err)
 	}
 
 	if !c.Bool("quiet") {
-		fmt.Fprintf(c.App.Writer, "Successfully created %s and %s for module %q.\n", MODULE_FILE_NAME, PLOT_FILE_NAME, moduleName)
+		fmt.Fprintf(c.App.Writer, "Successfully created %s and %s for module %q.\n", dab.MagicFilename_Module, dab.MagicFilename_Plot, moduleName)
 		fmt.Fprintf(c.App.Writer, "Ensure your catalogs are up to date by running `%s catalog update.`.\n", os.Args[0])
 		fmt.Fprintf(c.App.Writer, "You can check status of this module with `%s status`.\n", os.Args[0])
 		fmt.Fprintf(c.App.Writer, "You can run this module with `%s run`.\n", os.Args[0])
-		fmt.Fprintf(c.App.Writer, "Once you've run the Hello World example, edit the 'script' section of %s to customize what happens.\n", PLOT_FILE_NAME)
+		fmt.Fprintf(c.App.Writer, "Once you've run the Hello World example, edit the 'script' section of %s to customize what happens.\n", dab.MagicFilename_Plot)
 	}
 
 	return nil

--- a/cmd/warpforge/run.go
+++ b/cmd/warpforge/run.go
@@ -107,6 +107,7 @@ func cmdRun(c *cli.Context) error {
 		if err != nil {
 			return fmt.Errorf("could not get current directory")
 		}
+		pwd = pwd[1:] // Drop leading slash, for use with fs package.
 		_, err = execModule(ctx, fsys, config, filepath.Join(pwd, dab.MagicFilename_Module))
 		if err != nil {
 			return err

--- a/cmd/warpforge/util.go
+++ b/cmd/warpforge/util.go
@@ -2,21 +2,13 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/ipld/go-ipld-prime"
-	"github.com/ipld/go-ipld-prime/codec/json"
 	"github.com/warpfork/warpforge/pkg/workspace"
-	"github.com/warpfork/warpforge/wfapi"
 )
-
-// special file names for plot and module files
-// these are json files with special formatting for detection
-const PLOT_FILE_NAME = "plot.wf"
-const MODULE_FILE_NAME = "module.wf"
 
 // Returns the file type, which is the file name without extension
 // e.g., formula.wf -> formula, module.wf -> module, etc...
@@ -49,53 +41,15 @@ func binPath(bin string) (string, error) {
 // stack: a workspace stack starting at the current working directory,
 // root workspace: the first marked root workspace in the stack, or the home workspace if none are marked,
 // home workspace: the workspace at the user's homedir
-func openWorkspaceSet() (workspace.WorkspaceSet, error) {
+func openWorkspaceSet(fsys fs.FS) (workspace.WorkspaceSet, error) {
 	pwd, err := os.Getwd()
 	if err != nil {
 		return workspace.WorkspaceSet{}, fmt.Errorf("failed to get working directory: %s", err)
 	}
 
-	wss, err := workspace.OpenWorkspaceSet(os.DirFS("/"), "", pwd[1:])
+	wss, err := workspace.OpenWorkspaceSet(fsys, "", pwd[1:])
 	if err != nil {
 		return workspace.WorkspaceSet{}, fmt.Errorf("failed to open workspace: %s", err)
 	}
 	return wss, nil
-}
-
-// takes a path to a plot file, returns a plot
-func plotFromFile(filename string) (wfapi.Plot, error) {
-	f, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return wfapi.Plot{}, err
-	}
-
-	plotCapsule := wfapi.PlotCapsule{}
-	_, err = ipld.Unmarshal(f, json.Decode, &plotCapsule, wfapi.TypeSystem.TypeByName("PlotCapsule"))
-	if err != nil {
-		return wfapi.Plot{}, err
-	}
-	if plotCapsule.Plot == nil {
-		return wfapi.Plot{}, fmt.Errorf("no v1 Plot in PlotCapsule")
-	}
-
-	return *plotCapsule.Plot, nil
-}
-
-// takes a path to a module file, returns a module
-func moduleFromFile(filename string) (wfapi.Module, error) {
-	f, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return wfapi.Module{}, err
-	}
-
-	moduleCapsule := wfapi.ModuleCapsule{}
-	_, err = ipld.Unmarshal(f, json.Decode, &moduleCapsule, wfapi.TypeSystem.TypeByName("ModuleCapsule"))
-	if err != nil {
-		return wfapi.Module{}, err
-	}
-	if moduleCapsule.Module == nil {
-		return wfapi.Module{}, fmt.Errorf("no v1 Module in ModuleCapsule")
-	}
-
-	return *moduleCapsule.Module, nil
 }

--- a/cmd/warpforge/util.go
+++ b/cmd/warpforge/util.go
@@ -42,7 +42,7 @@ func binPath(bin string) (string, error) {
 // root workspace: the first marked root workspace in the stack, or the home workspace if none are marked,
 // home workspace: the workspace at the user's homedir
 func openWorkspaceSet(fsys fs.FS) (workspace.WorkspaceSet, error) {
-	pwd, err := os.Getwd()
+	pwd, err := os.Getwd() // FIXME why are you doing this again?  you almost certainly already did it moments ago.
 	if err != nil {
 		return workspace.WorkspaceSet{}, fmt.Errorf("failed to get working directory: %s", err)
 	}

--- a/cmd/warpforge/winspect.go
+++ b/cmd/warpforge/winspect.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/warpfork/warpforge/pkg/dab"
-
 	"github.com/urfave/cli/v2"
+
+	"github.com/warpfork/warpforge/pkg/dab"
+	"github.com/warpfork/warpforge/pkg/plotexec"
 )
 
 var cmdDefWorkspaceInspect = cli.Command{
@@ -16,6 +17,13 @@ var cmdDefWorkspaceInspect = cli.Command{
 	Usage:  "Inspect and report upon the situation of the current workspace (how many modules are there, have we got a cached evaluation of them, etc).",
 	Action: cmdFnWorkspaceInspect,
 	// Aliases: []string{"winspect"}, // doesn't put them at the top level.  Womp.
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "gohard",
+			Usage: "whether to spend effort checking the health of modules found; if false, just list them.",
+			Value: true,
+		},
+	},
 }
 
 func cmdFnWorkspaceInspect(c *cli.Context) error {
@@ -33,7 +41,7 @@ func cmdFnWorkspaceInspect(c *cli.Context) error {
 	fmt.Fprintf(c.App.Writer, "Workspace: %s%s\n", wsFs, wsPath)
 
 	// Search for modules within the workspace.
-	fs.WalkDir(wsFs, wsPath, func(path string, d fs.DirEntry, err error) error {
+	return fs.WalkDir(wsFs, wsPath, func(path string, d fs.DirEntry, err error) error {
 		// fmt.Fprintf(c.App.Writer, "hi: %s%s\n", wsFs, path)
 
 		if err != nil {
@@ -66,12 +74,50 @@ func cmdFnWorkspaceInspect(c *cli.Context) error {
 				modName = "!!Unknown!!"
 			}
 
+			everythingParses := false
+			importsResolve := false
+			noticeIngestUsage := false
+			noticeMountUsage := false
+			havePacksCached := false // maybe should have a variant for "or we have a replay we're hopeful about"?
+			haveRunrecord := false
+			haveHappyExit := false
+			if c.Bool("gohard") {
+				if err != nil {
+					goto _checksDone
+				}
+				plot, err := dab.PlotFromFile(wsFs, filepath.Join(filepath.Dir(path), dab.MagicFilename_Plot))
+				if err != nil {
+					goto _checksDone
+				}
+				everythingParses = true
+				plotStats, err := plotexec.ComputeStats(plot, wss)
+				if err != nil {
+					return err // if it's hardcore catalog errors, rather than just unresolvables, I'm out
+				}
+				if plotStats.ResolvableCatalogInputs == plotStats.InputsUsingCatalog {
+					importsResolve = true
+				}
+				if plotStats.InputsUsingIngest > 0 {
+					noticeIngestUsage = true
+				}
+				if plotStats.InputsUsingMount > 0 {
+					noticeMountUsage = true
+				}
+				// TODO: havePacksCached is not supported right now :(
+				// TODO: haveRunrecord needs to both do resolve, and go peek at memos, and yet (obviously) not actually run.
+				// TODO: haveHappyExit needs the above.
+			}
+		_checksDone:
+
 			// Tell me about it.
-			fmt.Fprintf(c.App.Writer, "Module found: %q -- at path %q\n", modName, modPathWithinWs)
+			fmt.Fprintf(c.App.Writer, "Module found: %q -- at path %q", modName, modPathWithinWs)
+			if c.Bool("gohard") {
+				fmt.Fprintf(c.App.Writer, " -- %v %v %v %v %v %v %v",
+					everythingParses, importsResolve, noticeIngestUsage, noticeMountUsage, havePacksCached, haveRunrecord, haveHappyExit)
+			}
+			fmt.Fprintf(c.App.Writer, "\n")
 		}
 
 		return nil
 	})
-
-	return nil
 }

--- a/cmd/warpforge/winspect.go
+++ b/cmd/warpforge/winspect.go
@@ -119,7 +119,8 @@ func cmdFnWorkspaceInspect(c *cli.Context) error {
 		_checksDone:
 
 			// Tell me about it.
-			fmt.Fprintf(c.App.Writer, "Module found: %q -- at path %q", modName, modPathWithinWs)
+			// FUTURE: perhaps a workspace configuration option for defaults for these padding sizes.
+			fmt.Fprintf(c.App.Writer, "Module found: %-40q -- at path %-26q", modName, modPathWithinWs)
 			if c.Bool("gohard") {
 				fmt.Fprintf(c.App.Writer, " -- %v %v %v %v %v %v %v",
 					glyphCheckOrKlaxon(everythingParses),

--- a/cmd/warpforge/winspect.go
+++ b/cmd/warpforge/winspect.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/warpfork/warpforge/pkg/dab"
+
+	"github.com/urfave/cli/v2"
+)
+
+var cmdDefWorkspaceInspect = cli.Command{
+	Name:   "inspect",
+	Usage:  "Inspect and report upon the situation of the current workspace (how many modules are there, have we got a cached evaluation of them, etc).",
+	Action: cmdFnWorkspaceInspect,
+	// Aliases: []string{"winspect"}, // doesn't put them at the top level.  Womp.
+}
+
+func cmdFnWorkspaceInspect(c *cli.Context) error {
+	fsys := os.DirFS("/")
+
+	// First, find the workspace.
+	wss, err := openWorkspaceSet(fsys)
+	if err != nil {
+		return fmt.Errorf("failed to open workspace set: %s", err)
+	}
+
+	// Briefly report on the nearest workspace.
+	// (We could talk about the grandparents too, but 'wf status' already does that; here we want to focus more on contents than parentage.)
+	wsFs, wsPath := wss.Stack[0].Path()
+	fmt.Fprintf(c.App.Writer, "Workspace: %s%s\n", wsFs, wsPath)
+
+	// Search for modules within the workspace.
+	fs.WalkDir(wsFs, wsPath, func(path string, d fs.DirEntry, err error) error {
+		// fmt.Fprintf(c.App.Writer, "hi: %s%s\n", wsFs, path)
+
+		if err != nil {
+			return err
+		}
+
+		// Don't ever look into warpforge guts directories.
+		if d.Name() == dab.MagicFilename_Workspace {
+			return fs.SkipDir
+		}
+
+		// If this is a dir (beyond the root): look see if it contains a workspace marker.
+		// If it does, we might not want to report on it.
+		// TODO: a bool flag for this.
+		if d.IsDir() && len(path) > len(wsPath) {
+			_, e2 := fs.Stat(wsFs, filepath.Join(path, dab.MagicFilename_Workspace))
+			if e2 == nil || os.IsNotExist(e2) {
+				// carry on
+			} else {
+				return fs.SkipDir
+			}
+		}
+
+		// Peek for module file.
+		if d.Name() == dab.MagicFilename_Module {
+			modPathWithinWs := path[len(wsPath)+1 : len(path)-len(dab.MagicFilename_Module)] // leave the trailing slash on.  For disambig in case we support multiple module files per dir someday.
+			mod, err := dab.ModuleFromFile(wsFs, path)
+			modName := mod.Name
+			if err != nil {
+				modName = "!!Unknown!!"
+			}
+
+			// Tell me about it.
+			fmt.Fprintf(c.App.Writer, "Module found: %q -- at path %q\n", modName, modPathWithinWs)
+		}
+
+		return nil
+	})
+
+	return nil
+}

--- a/pkg/dab/doc.go
+++ b/pkg/dab/doc.go
@@ -1,0 +1,23 @@
+/*
+	Package dab -- short for Data Access Broker -- contains functions that help save and load data,
+	mostly to a local filesystem (but sometimes to a blind content-addressed objectstore, as well).
+
+	Most dab functions return objects from the wfapi package.
+	Some return a dab type, in which case that object is to help manage further access --
+	but eventually you should still reach wfapi data types.
+
+	Functions that deal with the filesystem may expect to be dealing with either
+	a workspace filesystem (e.g., conmingled with other user files),
+	or a catalog filesystem projection (a somewhat stricter situation).
+	Sometimes these are the same.
+	The function name should provide a hint about which situations it handles.
+
+	Sometimes, search features are provided for workspace filesystems,
+	since there is no other index of those contents aside from the filesystem itself.
+
+	Most of these functions return the "latest" version of their relevant API type.
+	At the moment, that's not saying much, because we haven't grown in such a way
+	that we support major varations of API object reversions -- but in the future,
+	this means these functions may do "migrational" transforms to the data on the fly.
+*/
+package dab

--- a/pkg/dab/module.go
+++ b/pkg/dab/module.go
@@ -1,0 +1,78 @@
+package dab
+
+import (
+	"fmt"
+	"io/fs"
+
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/codec/json"
+
+	"github.com/warpfork/warpforge/wfapi"
+)
+
+const (
+	MagicFilename_Module = "module.wf"
+	MagicFilename_Plot   = "plot.wf"
+)
+
+// ModuleFromFile loads a wfapi.Module from filesystem path.
+//
+// In typical usage, the filename parameter will have the suffix of MagicFilename_Module.
+//
+// Errors:
+//
+// 	- warpforge-error-io -- for errors reading from fsys.
+// 	- warpforge-error-serialization -- for errors from try to parse the data as a Module.
+// 	- warpforge-error-datatoonew -- if encountering unknown data from a newer version of warpforge!
+//
+func ModuleFromFile(fsys fs.FS, filename string) (wfapi.Module, error) {
+	situation := "loading a module"
+
+	f, err := fs.ReadFile(fsys, filename)
+	if err != nil {
+		return wfapi.Module{}, wfapi.ErrorIo(situation, &filename, err)
+	}
+
+	moduleCapsule := wfapi.ModuleCapsule{}
+	_, err = ipld.Unmarshal(f, json.Decode, &moduleCapsule, wfapi.TypeSystem.TypeByName("ModuleCapsule"))
+	if err != nil {
+		return wfapi.Module{}, wfapi.ErrorSerialization(situation, err)
+	}
+	if moduleCapsule.Module == nil {
+		// ... this isn't really reachable.
+		return wfapi.Module{}, wfapi.ErrorDataTooNew(situation, fmt.Errorf("no v1 Module in ModuleCapsule"))
+	}
+
+	return *moduleCapsule.Module, nil
+}
+
+// PlotFromFile loads a wfapi.Plot from filesystem path.
+//
+// In typical usage, the filename parameter will have the suffix of MagicFilename_Plot.
+//
+// Errors:
+//
+// 	- warpforge-error-io -- for errors reading from fsys.
+// 	- warpforge-error-serialization -- for errors from try to parse the data as a Plot.
+// 	- warpforge-error-datatoonew -- if encountering unknown data from a newer version of warpforge!
+//
+func PlotFromFile(fsys fs.FS, filename string) (wfapi.Plot, error) {
+	situation := "loading a plot"
+
+	f, err := fs.ReadFile(fsys, filename)
+	if err != nil {
+		return wfapi.Plot{}, wfapi.ErrorIo(situation, &filename, err)
+	}
+
+	plotCapsule := wfapi.PlotCapsule{}
+	_, err = ipld.Unmarshal(f, json.Decode, &plotCapsule, wfapi.TypeSystem.TypeByName("PlotCapsule"))
+	if err != nil {
+		return wfapi.Plot{}, wfapi.ErrorSerialization(situation, err)
+	}
+	if plotCapsule.Plot == nil {
+		// ... this isn't really reachable.
+		return wfapi.Plot{}, wfapi.ErrorDataTooNew(situation, fmt.Errorf("no v1 Plot in PlotCapsule"))
+	}
+
+	return *plotCapsule.Plot, nil
+}

--- a/pkg/dab/workspace.go
+++ b/pkg/dab/workspace.go
@@ -1,0 +1,5 @@
+package dab
+
+const (
+	MagicFilename_Workspace = ".warpforge"
+)

--- a/pkg/plotexec/plot_stats.go
+++ b/pkg/plotexec/plot_stats.go
@@ -1,0 +1,57 @@
+package plotexec
+
+import (
+	"github.com/warpfork/warpforge/pkg/workspace"
+	"github.com/warpfork/warpforge/wfapi"
+)
+
+// Might not match the package name -- funcs in this file certainly don't exec anything.
+
+type PlotStats struct {
+	InputsUsingCatalog      int
+	InputsUsingIngest       int
+	InputsUsingMount        int
+	ResolvableCatalogInputs int
+	ResolvedCatalogInputs   map[wfapi.CatalogRef]wfapi.WareID // might as well remember it if we already did all that work.
+	UnresolvedCatalogInputs map[wfapi.CatalogRef]struct{}
+}
+
+// ComputeStats counts up how many times a plot uses various features,
+// and also checks for reference resolvablity.
+func ComputeStats(plot wfapi.Plot, wsSet workspace.WorkspaceSet) (PlotStats, error) {
+	v := PlotStats{
+		ResolvedCatalogInputs:   make(map[wfapi.CatalogRef]wfapi.WareID),
+		UnresolvedCatalogInputs: make(map[wfapi.CatalogRef]struct{}),
+	}
+	for _, input := range plot.Inputs.Values {
+		inputBasis := input.Basis() // unwrap if it's a complex filtered thing.
+		switch {
+		// This switch should be exhaustive on the possible members of PlotInputSimple.
+		case inputBasis.WareID != nil:
+			// not interesting :)
+		case inputBasis.Mount != nil:
+			v.InputsUsingMount++
+		case inputBasis.Literal != nil:
+			// not interesting :)
+		case inputBasis.Pipe != nil:
+			// not interesting :)
+		case inputBasis.CatalogRef != nil:
+			v.InputsUsingCatalog++
+			ware, _, err := wsSet.GetCatalogWare(*inputBasis.CatalogRef)
+			if err != nil {
+				return v, err // These mean catalog read failed entirely, so we're in deep water.
+			}
+			if ware == nil {
+				v.UnresolvedCatalogInputs[*inputBasis.CatalogRef] = struct{}{}
+			} else {
+				v.ResolvableCatalogInputs++
+				v.ResolvedCatalogInputs[*inputBasis.CatalogRef] = *ware
+			}
+		case inputBasis.Ingest != nil:
+			v.InputsUsingIngest++
+		default:
+			panic("unreachable")
+		}
+	}
+	return v, nil
+}

--- a/pkg/workspace/fsdetect.go
+++ b/pkg/workspace/fsdetect.go
@@ -6,11 +6,12 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/warpfork/warpforge/pkg/dab"
 	"github.com/warpfork/warpforge/wfapi"
 )
 
 const (
-	magicWorkspaceDirname = ".warpforge"
+	magicWorkspaceDirname = dab.MagicFilename_Workspace
 )
 
 var homedir string

--- a/pkg/workspace/workspace_set.go
+++ b/pkg/workspace/workspace_set.go
@@ -14,7 +14,7 @@ import (
 type WorkspaceSet struct {
 	Home  *Workspace
 	Root  *Workspace
-	Stack []*Workspace
+	Stack []*Workspace // the 0'th index is the closest workspace; the next is its parent, and so on.
 }
 
 // Opens a full WorkspaceSet

--- a/wfapi/error.go
+++ b/wfapi/error.go
@@ -175,6 +175,24 @@ func ErrorSerialization(context string, cause error) Error {
 	}
 }
 
+// ErrorDataTooNew is returned when some data was (partially) deserialized,
+// but only enough that we could recognize it as being a newer version of message
+// than this application supports.
+//
+// Errors:
+//
+//    - warpforge-error-datatoonew -- if some data is too new to parse completely.
+func ErrorDataTooNew(context string, cause error) Error {
+	return &ErrorVal{
+		CodeString: "warpforge-error-datatoonew",
+		Message:    fmt.Sprintf("while %s, encountered data from an unknown version: %s", context, cause),
+		Details: [][2]string{
+			{"context", context},
+		},
+		Cause: wrapErr(cause),
+	}
+}
+
 // ErrorWareUnpack is returned when the unpacking of a ware fails
 //
 // Errors:


### PR DESCRIPTION
I got busy without network for a while, so a heap of things come at once (the individual commits may end up more sane to review than the whole PR at once):

- A new package is introduced, to be the home of anything to do with filesystem and data loading (see big doc file);
- A copious amount of refactoring to use `fs.FS` in more places;
- And there is now a `workspace inspect` subcommand, which takes a look around to see all the modules it can see, and gives some brief reporting on their health (are all imports resolvable, etc).
- Extracted some stats counting features for Plots to be reusable to serve that (it's the same stuff as `wf status` is doing, just now in bulk).
- (rather importantly) fixed that Plot stat counting stuff to be correctly recursive, rather than forget to count things beyond the top level object!

Everything about the appearance of the `workspace inspect` command should be considered comically WIP, for 'tis terribly ugly, but I hope it's an interesting start in a direction.