### PR TITLE
style module and release pages

### DIFF
--- a/pkg/cataloghtml/catalogIndex.tmpl.html
+++ b/pkg/cataloghtml/catalogIndex.tmpl.html
@@ -21,7 +21,10 @@ which is not available and rigged up as a convenient library yet.
 <input type="checkbox" id="dark-mode-checkbox" />
 <div class="container">
 	<div class="header">
-		<h1 style="display:inline">Catalog</h1>
+		<div>
+			<small>&nbsp;</small>
+			<h1>Catalog</h1>
+		</div>
 		<div class="theme-switch-wrapper">
 			<label class="theme-switch" for="dark-mode-checkbox">
 				<div class="slider round">
@@ -31,9 +34,11 @@ which is not available and rigged up as a convenient library yet.
 			</label>
 		</div>
 	</div>
+	<div class="content content-heading">
+		<strong>Modules</strong>
+	</div>
 	<div class="content-wrapper">
 		<div class="content">
-			<h2>Modules</h2>
 			<ul>
 				{{- range $moduleName := . }}
 				<li><a href="{{ (url (string $moduleName) "_module.html") }}">{{ $moduleName }}</a></li>

--- a/pkg/cataloghtml/catalogModule.tmpl.html
+++ b/pkg/cataloghtml/catalogModule.tmpl.html
@@ -1,26 +1,55 @@
 <html>
+
 <head>
-	<!--
 	<link rel="stylesheet" href="{{ (url "css.css") }}" />
-	<script src="{{ (url "js.js") }}" ></script>
- 	-->
+	<script src="{{ (url "js.js") }}"></script>
 </head>
+
 <body>
-	<div style="border: 1px solid; padding: 0.5em;">
-		<i>module:</i>
-		<h1 style="display:inline">{{ .Name }}</h1>
+	<input type="checkbox" id="dark-mode-checkbox" />
+	<div class="container">
+		<div class="header">
+			<div>
+				<small><i><a href="{{ (url "index.html") }}">Catalog</a> > module</i></small>
+				<h1>{{ .Name }}</h1>
+			</div>
+			<div class="theme-switch-wrapper">
+				<label class="theme-switch" for="dark-mode-checkbox">
+					<div class="slider round">
+						<div class="sun-ray-1"></div>
+						<div class="sun-ray-2"></div>
+					</div>
+				</label>
+			</div>
+		</div>
+		<input checked name="content-type" type="radio" id="releases-radiobutton" />
+		<input name="content-type" type="radio" id="metadata-radiobutton" />
+		<div class="content-selection">
+			<label id="release-label" for="releases-radiobutton"><strong>Releases</strong></label>
+			<label id="metadata-label" for="metadata-radiobutton"><strong>Metadata</strong></label>
+		</div>
+		<div class="content-wrapper">
+			<div class="content">
+				<div class="releases">
+					<ul>
+						{{- $dot := . -}}
+						{{- range $releaseKey := .Releases.Keys }}
+						<li><a href="{{ (url (string $dot.Name) "_releases" (print $releaseKey ".html" )) }}">{{
+								$releaseKey }}</a>
+							<small>(cid: {{ index $dot.Releases.Values $releaseKey }})</small>
+						</li>
+						{{- end }}
+					</ul>
+				</div>
+				<div class="metadata">
+					{{- range $metadataKey := .Metadata.Keys }}
+					<dt>{{ $metadataKey }}</dt>
+					<dd>{{ index $dot.Metadata.Values $metadataKey }}</dd>
+					{{- end }}
+				</div>
+			</div>
+		</div>
 	</div>
-	(<a href="{{ (url "index.html") }}">back to root</a>)
-	<h2>releases</h2>
-	<ul>
-	{{- $dot := . -}}
-	{{- range $releaseKey := .Releases.Keys }}
-		<li><a href="{{ (url (string $dot.Name) "_releases" (print $releaseKey ".html")) }}">{{ $releaseKey }}</a> <small>(cid: {{ index $dot.Releases.Values $releaseKey }})</small></li>
-	{{- end }}
-	</ul>
-	<h2>metadata</h2>
-	{{- range $metadataKey := .Metadata.Keys }}
-		<dt>{{ $metadataKey }}</dt><dd>{{ index $dot.Metadata.Values $metadataKey }}</dd>
-	{{- end }}
 </body>
+
 </html>

--- a/pkg/cataloghtml/catalogModule.tmpl.html
+++ b/pkg/cataloghtml/catalogModule.tmpl.html
@@ -22,15 +22,15 @@
 				</label>
 			</div>
 		</div>
-		<input checked name="content-type" type="radio" id="releases-radiobutton" />
-		<input name="content-type" type="radio" id="metadata-radiobutton" />
-		<div class="content-selection">
-			<label id="release-label" for="releases-radiobutton"><strong>Releases</strong></label>
-			<label id="metadata-label" for="metadata-radiobutton"><strong>Metadata</strong></label>
+		<input class="tab-radiobutton" checked name="tabs" type="radio" id="tab-radiobutton-1">
+		<input class="tab-radiobutton" name="tabs" type="radio" id="tab-radiobutton-2">
+		<div class="tabs">
+			<label for="tab-radiobutton-1"><strong>Releases</strong></label>
+			<label for="tab-radiobutton-2"><strong>Metadata</strong></label>
 		</div>
 		<div class="content-wrapper">
 			<div class="content">
-				<div class="releases">
+				<div class="tab-content">
 					<ul>
 						{{- $dot := . -}}
 						{{- range $releaseKey := .Releases.Keys }}
@@ -41,7 +41,7 @@
 						{{- end }}
 					</ul>
 				</div>
-				<div class="metadata">
+				<div class="tab-content">
 					{{- range $metadataKey := .Metadata.Keys }}
 					<dt>{{ $metadataKey }}</dt>
 					<dd>{{ index $dot.Metadata.Values $metadataKey }}</dd>

--- a/pkg/cataloghtml/catalogRelease.tmpl.html
+++ b/pkg/cataloghtml/catalogRelease.tmpl.html
@@ -1,28 +1,53 @@
 <html>
+
 <head>
-	<!--
 	<link rel="stylesheet" href="{{ (url "css.css") }}" />
 	<script src="{{ (url "js.js") }}" ></script>
- 	-->
 </head>
+
 <body>
-	<div style="border: 1px solid; padding: 0.5em;">
-		<i>module:</i>
-		<h1 style="display:inline">{{ .Module.Name }}</h1>
-		<i>release:</i>
-		<h1 style="display:inline">{{ .Release.ReleaseName }}</h1>
+	<input type="checkbox" id="dark-mode-checkbox">
+	<div class="container">
+		<div class="header">
+			<div>
+				<small><i><a href="{{ (url "index.html") }}">Catalog</a> &gt; 
+					<a href="{{ (url (string .Module.Name) "_module.html") }}">{{ .Module.Name }}</a> &gt; {{ .Release.ReleaseName }} </i></small>
+				<h1>{{ .Module.Name }}</h1>
+			</div>
+			<div class="theme-switch-wrapper">
+				<label class="theme-switch" for="dark-mode-checkbox">
+					<div class="slider round">
+						<div class="sun-ray-1"></div>
+						<div class="sun-ray-2"></div>
+					</div>
+				</label>
+			</div>
+		</div>
+		<input class="tab-radiobutton" checked name="tabs" type="radio" id="tab-radiobutton-1">
+		<input class="tab-radiobutton" name="tabs" type="radio" id="tab-radiobutton-2">
+		<div class="tabs">
+			<label for="tab-radiobutton-1"><strong>Items</strong></label>
+			<label for="tab-radiobutton-2"><strong>Metadata</strong></label>
+		</div>
+		<div class="content-wrapper">
+			<div class="content">
+				<div class="tab-content">
+					<ul>
+						{{- $dot := .Release -}}
+						{{- range $itemKey := .Release.Items.Keys }}
+						<li>{{ $itemKey }} : {{ index $dot.Items.Values $itemKey }}</li>
+						{{- end }}
+					</ul>
+				</div>
+				<div class="tab-content">
+					{{- range $metadataKey := .Release.Metadata.Keys }}
+					<dt>{{ $metadataKey }}</dt>
+					<dd>{{ index $dot.Metadata.Values $metadataKey }}</dd>
+					{{- end }}
+				</div>
+			</div>
+		</div>
 	</div>
-	(<a href="{{ (url "index.html") }}">back to root</a>; <a href="{{ (url (string .Module.Name) "_module.html") }}">back to module index</a>)
-	<h2>items</h2>
-	<ul>
-	{{- $dot := .Release -}}
-	{{- range $itemKey := .Release.Items.Keys }}
-		<li>{{ $itemKey }} : {{ index $dot.Items.Values $itemKey }}</li>
-	{{- end }}
-	</ul>
-	<h2>metadata</h2>
-	{{- range $metadataKey := .Release.Metadata.Keys }}
-		<dt>{{ $metadataKey }}</dt><dd>{{ index $dot.Metadata.Values $metadataKey }}</dd>
-	{{- end }}
 </body>
+
 </html>

--- a/pkg/cataloghtml/css.css
+++ b/pkg/cataloghtml/css.css
@@ -292,6 +292,24 @@ li {
 	background-color: var(--black);
 }
 
+/* Index page */
+.content-heading > strong {
+	position: relative;
+}
+
+.content-heading > strong:before {
+	content: '';
+	border: 20px solid var(--code-bg-color);
+	border-left-color: transparent;
+	border-right-color: transparent;
+	border-top-color: transparent;
+	position: absolute;
+	top: var(--space-md);
+	left: 50%;
+	transform: translateX(-50%);
+	cursor: default;
+}
+
 /* Release & Module page */
 
 .tab-content {
@@ -335,7 +353,7 @@ li {
 	position: absolute;
 	top: var(--space-md);
 	left: 50%;
-	transform: translateX(-50%);
+	transform: translatex(-50%);
 	cursor: default;
 }
 

--- a/pkg/cataloghtml/css.css
+++ b/pkg/cataloghtml/css.css
@@ -304,6 +304,7 @@ li {
 #releases-radiobutton:checked ~ .content-wrapper .releases,
 #metadata-radiobutton:checked ~ .content-wrapper .metadata {
 	opacity: 1;
+	height: initial;
 }
 
 .content-selection {

--- a/pkg/cataloghtml/css.css
+++ b/pkg/cataloghtml/css.css
@@ -100,7 +100,6 @@ body > input {
 	flex-direction: column;
 	align-items: center;
 	min-height: 100%;
-	transition: 0.3s all;
 }
 
 /* Structural classes */
@@ -191,7 +190,7 @@ li {
 	height: 18px;
 	left: 2px;
 	position: absolute;
-	transition: 0.4s;
+	transition: 0.3s;
 	width: 18px;
 }
 
@@ -293,37 +292,41 @@ li {
 	background-color: var(--black);
 }
 
-/* Modules page */
-.releases,
-.metadata {
+/* Release & Module page */
+
+.tab-content {
 	height: 0;
 	opacity: 0;
-	transition: 0.1s 0.1s all;
+	word-break: break-all;
 }
 
-#releases-radiobutton:checked ~ .content-wrapper .releases,
-#metadata-radiobutton:checked ~ .content-wrapper .metadata {
-	opacity: 1;
-	height: initial;
-}
-
-.content-selection {
+.tabs {
 	padding: var(--space-lg);
 	display: flex;
 	flex-wrap: nowrap;
-    width: 100%;
-    max-width: 1200px;
+	width: 100%;
+	max-width: 1200px;
 }
 
-.content-selection > label {
+.tabs > label {
 	display: inline-block;
 	cursor: pointer;
 	margin-right: var(--space-md);
 	position: relative;
 }
 
-#releases-radiobutton:checked ~ .content-selection #release-label:before,
-#metadata-radiobutton:checked ~ .content-selection #metadata-label:before {
+.tab-radiobutton {
+	display: none;
+}
+
+/* 
+	If there's more than 2 tabs we can just add another count here.
+	Unfortunately it doesn't seem like we can just iterate using
+	a simple function here since .tab-radiobutton:nth-of-type(x) 
+	needs to match .tab-content:nth-of-type(y). (x = y)
+*/
+.tab-radiobutton:nth-of-type(1):checked ~ .tabs > label:nth-of-type(1):before,
+.tab-radiobutton:nth-of-type(2):checked ~ .tabs > label:nth-of-type(2):before {
 	content: '';
 	border: 20px solid var(--code-bg-color);
 	border-left-color: transparent;
@@ -336,7 +339,16 @@ li {
 	cursor: default;
 }
 
-#releases-radiobutton,
-#metadata-radiobutton {
-	display: none;
+/* 
+	Same as above, we want different nth-of-type to match which gets tricky,
+	so for now we count manually.
+*/
+.tab-radiobutton:nth-of-type(1):checked
+	~ .content-wrapper
+	.tab-content:nth-of-type(1),
+.tab-radiobutton:nth-of-type(2):checked
+	~ .content-wrapper
+	.tab-content:nth-of-type(2) {
+	opacity: 1;
+	height: initial;
 }

--- a/pkg/cataloghtml/css.css
+++ b/pkg/cataloghtml/css.css
@@ -81,6 +81,7 @@
 body {
 	height: 100%;
 	font-family: Verdana, Geneva, Tahoma, sans-serif;
+	font-size: 16px;
 }
 
 body > input {
@@ -109,9 +110,10 @@ body > input {
 	max-width: 1200px;
 	position: relative;
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	justify-content: space-between;
 	padding: var(--space-lg);
+	margin-bottom: var(--space-xxl);
 }
 
 .header h1 {
@@ -123,7 +125,6 @@ body > input {
 	background-color: var(--code-bg-color);
 	display: flex;
 	justify-content: center;
-	margin-top: var(--space-xxl);
 	flex-grow: 2;
 }
 
@@ -290,4 +291,48 @@ li {
 	height: 4px;
 	width: 2px;
 	background-color: var(--black);
+}
+
+/* Modules page */
+.releases,
+.metadata {
+	height: 0;
+	opacity: 0;
+	transition: 0.1s 0.1s all;
+}
+
+#releases-radiobutton:checked ~ .content-wrapper .releases,
+#metadata-radiobutton:checked ~ .content-wrapper .metadata {
+	opacity: 1;
+}
+
+.content-selection {
+	padding: var(--space-lg);
+	align-self: flex-start;
+}
+
+.content-selection > label {
+	display: inline-block;
+	cursor: pointer;
+	margin-right: var(--space-md);
+	position: relative;
+}
+
+#releases-radiobutton:checked ~ .content-selection #release-label:before,
+#metadata-radiobutton:checked ~ .content-selection #metadata-label:before {
+	content: '';
+	border: 20px solid var(--code-bg-color);
+	border-left-color: transparent;
+	border-right-color: transparent;
+	border-top-color: transparent;
+	position: absolute;
+	top: var(--space-md);
+	left: 50%;
+	transform: translateX(-50%);
+	cursor: default;
+}
+
+#releases-radiobutton,
+#metadata-radiobutton {
+	display: none;
 }

--- a/pkg/cataloghtml/css.css
+++ b/pkg/cataloghtml/css.css
@@ -308,7 +308,10 @@ li {
 
 .content-selection {
 	padding: var(--space-lg);
-	align-self: flex-start;
+	display: flex;
+	flex-wrap: nowrap;
+    width: 100%;
+    max-width: 1200px;
 }
 
 .content-selection > label {


### PR DESCRIPTION
## Description

Style catalogModule.tmpl.html and catalogRelease.tmpl.html to make them easier to navigate.

## Tasks

- [x] Breadcrumbs for easy overview of where you have navigated (and good way to get back)
- [x] Dark / light-mode
- [x] Toggling between tabs of data, it's better to show one at a time so the user easier understands and knows what they are looking at. Especially if there's a lot of data to view.
- [x] Don't add any unnecessary javascript

## How has this been tested?

Specify the platform(s) on which this was tested:
- Brave
- Chrome
- Safari