### PR TITLE
Add cli for catalog html generation

### DIFF
--- a/examples/500-cli/cli.md
+++ b/examples/500-cli/cli.md
@@ -383,6 +383,13 @@ warpforge catalog init my-catalog
 warpforge catalog ls
 ```
 
+### Generate Catalog HTML
+
+[testmark]:# (base-workspace/then-generatehtml/sequence)
+```
+warpforge catalog --name=test generate-html
+```
+
 ### Add an Item to a Catalog
 
 #### tar


### PR DESCRIPTION
Add a CLI for generating catalog html output.

By default, this will generate the output for the catalog `default` and place it into the `_html` subdirectory of that catalog. Flags can be used to change the catalog used, output directory and URL prefix:

`wf catalog --name=warpsys generate-html --output=/tmp/warpsys-catalog --url-prefix=https://example.com/some/prefix`

We may decide to only use relative paths and remove the need for `--url-prefix`. 