### PR TITLE
HTML Replays & Download Links

### DIFF
--- a/cmd/warpforge/catalog.go
+++ b/cmd/warpforge/catalog.go
@@ -94,7 +94,11 @@ var catalogCmdDef = cli.Command{
 				},
 				&cli.StringFlag{
 					Name:  "url-prefix",
-					Usage: "Url prefix for links within generated HTML",
+					Usage: "URL prefix for links within generated HTML",
+				},
+				&cli.StringFlag{
+					Name:  "download-url",
+					Usage: "URL for warehouse to use for download links",
 				},
 			},
 		},
@@ -736,11 +740,18 @@ func cmdGenerateHtml(c *cli.Context) error {
 		urlPrefix = c.String("url-prefix")
 	}
 
+	var warehouseUrl *string = nil
+	if c.String("download-url") != "" {
+		dlUrl := c.String("download-url")
+		warehouseUrl = &dlUrl
+	}
+
 	cfg := cataloghtml.SiteConfig{
-		Ctx:        context.Background(),
-		Cat_dab:    cat,
-		OutputPath: outputPath,
-		URLPrefix:  urlPrefix,
+		Ctx:         context.Background(),
+		Cat_dab:     cat,
+		OutputPath:  outputPath,
+		URLPrefix:   urlPrefix,
+		DownloadURL: warehouseUrl,
 	}
 	os.RemoveAll(cfg.OutputPath)
 	if err := cfg.CatalogAndChildrenToHtml(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ module github.com/warpfork/warpforge
 go 1.16
 
 require (
+	github.com/alecthomas/chroma v0.10.0
 	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb
 	github.com/fatih/color v1.13.0
 	github.com/frankban/quicktest v1.14.3

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C6
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
+github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
+github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -69,6 +71,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.4.0 h1:F1rxgk7p4uKjwIQxBs9oAXe5CqrXlCduYEJvrF4u93E=
+github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/pkg/cataloghtml/catalogRelease.tmpl.html
+++ b/pkg/cataloghtml/catalogRelease.tmpl.html
@@ -37,16 +37,24 @@
 			<div class="content">
 				<div class="tab-content">
 					<ul>
+						{{- $linkGen := .LinkGenerator -}}
+						{{- $linksAvailable := .LinkGenerator.DownloadLinksAvailable -}}
 						{{- $dot := .Release -}}
 						{{- range $itemKey := .Release.Items.Keys }}
-						<li>{{ $itemKey }} : {{ index $dot.Items.Values $itemKey }}</li>
+						{{ $item := index $dot.Items.Values $itemKey }}
+						<li>{{ $itemKey }} : {{ $item }} {{ if $linksAvailable }}<small>{{ ($linkGen.DownloadLink $item) }}</small>{{ end }}</li>
 						{{- end }}
 					</ul>
 				</div>
 				<div class="tab-content">
+					{{- $module := .Module }}
 					{{- range $metadataKey := .Release.Metadata.Keys }}
 					<dt>{{ $metadataKey }}</dt>
-					<dd>{{ index $dot.Metadata.Values $metadataKey }}</dd>
+					{{- if eq $metadataKey "replay" }}
+						<dd><a href="{{ (url (string $module.Name) "_replays" (index $dot.Metadata.Values $metadataKey)) }}.html">{{ index $dot.Metadata.Values $metadataKey }}</a></dd>
+					{{- else }}
+						<dd>{{ index $dot.Metadata.Values $metadataKey }}</dd>
+					{{- end }}
 					{{- end }}
 				</div>
 			</div>

--- a/pkg/cataloghtml/catalogReplay.tmpl.html
+++ b/pkg/cataloghtml/catalogReplay.tmpl.html
@@ -1,0 +1,46 @@
+<html>
+
+<head>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Replay for {{ .Module.Name }}:{{ .Release.ReleaseName }}</title>
+	<link rel="stylesheet" href="{{ (url "css.css") }}" />
+	<script src="{{ (url "js.js") }}"></script>
+</head>
+
+<body>
+	<input type="checkbox" id="dark-mode-checkbox">
+	<div class="container">
+		<div class="header">
+			<div>
+				<small><i><a href="{{ (url "index.html") }}">Catalog</a></i>
+					<i>&gt; <a href="{{ (url (string .Module.Name) "_module.html") }}">{{ .Module.Name }}</a></i>
+					<i>&gt; <a href="{{ (url (string .Module.Name) "_releases" (string .Release.ReleaseName)) }}.html">{{ .Release.ReleaseName }}</a></i>
+					<i>&gt; Replay</i></small>
+				<h1>{{ .Module.Name }}</h1>
+			</div>
+			<div class="theme-switch-wrapper">
+				<label class="theme-switch" for="dark-mode-checkbox">
+					<div class="slider round">
+						<div class="sun-ray-1"></div>
+						<div class="sun-ray-2"></div>
+					</div>
+				</label>
+			</div>
+		</div>
+		<input class="tab-radiobutton" checked name="tabs" type="radio" id="tab-radiobutton-1">
+		<div class="tabs">
+			<label for="tab-radiobutton-1"><strong>Plot</strong></label>
+		</div>
+		<div class="content-wrapper">
+			<div class="content">
+				<div class="tab-content">
+					<pre>
+						{{ ( .PlotFormatter.FormattedJson ) }}
+					</pre>
+				</div>
+			</div>
+		</div>
+	</div>
+</body>
+
+</html>

--- a/pkg/cataloghtml/catalogReplay.tmpl.html
+++ b/pkg/cataloghtml/catalogReplay.tmpl.html
@@ -34,9 +34,7 @@
 		<div class="content-wrapper">
 			<div class="content">
 				<div class="tab-content">
-					<pre>
-						{{ ( .PlotFormatter.FormattedJson ) }}
-					</pre>
+					{{ ( .PlotFormatter.FormattedJson ) }}
 				</div>
 			</div>
 		</div>

--- a/pkg/cataloghtml/cataloghtml.go
+++ b/pkg/cataloghtml/cataloghtml.go
@@ -299,10 +299,12 @@ func (pf plotFormatter) FormattedJson() template.HTML {
 	}
 
 	// replace catalog references with links
+	// quotations get replaced with their character code (&#34;), so we must
+	// use that for replacement
 	out := outBuf.String()
-	r := regexp.MustCompile("catalog:([^:\"<>]+):([^:\"<>]+):([^:\"<>]+)")
-	replaceStr := fmt.Sprintf("<a href=\"%s/$1/_releases/$2.html\">catalog:$1:$2:$3</a>", pf.cfg.URLPrefix)
-	out = string(r.ReplaceAll([]byte(out), []byte(replaceStr)))
+	r := regexp.MustCompile(`catalog:([^:]+):([^:]+):([^:&]+)&#34;`)
+	replaceStr := fmt.Sprintf("<a href=\"%s/$1/_releases/$2.html\">catalog:$1:$2:$3</a>&#34;", pf.cfg.URLPrefix)
+	out = string(r.ReplaceAllString(out, replaceStr))
 	return template.HTML(out)
 }
 

--- a/pkg/cataloghtml/cataloghtml.go
+++ b/pkg/cataloghtml/cataloghtml.go
@@ -93,6 +93,7 @@ func (cfg SiteConfig) tfuncs() map[string]interface{} {
 //   - warpforge-error-internal -- in case of templating errors.
 //   - warpforge-error-catalog-invalid -- in case the catalog data is invalid.
 //   - warpforge-error-catalog-parse -- in case the catalog data failed to parse entirely.
+//   - warpforge-error-serialization -- in case the replay plot serialization fails
 func (cfg SiteConfig) CatalogAndChildrenToHtml() error {
 	// Emit catalog index.
 	if err := cfg.CatalogToHtml(); err != nil {
@@ -172,6 +173,7 @@ func (cfg SiteConfig) CatalogToHtml() error {
 //   - warpforge-error-internal -- in case of templating errors.
 //   - warpforge-error-catalog-invalid -- in case the catalog data is invalid.
 //   - warpforge-error-catalog-parse -- in case the catalog data failed to parse entirely.
+//   - warpforge-error-serialization -- in case the replay plot serialization fails
 func (cfg SiteConfig) CatalogModuleAndChildrenToHtml(catMod wfapi.CatalogModule) error {
 	if err := cfg.CatalogModuleToHtml(catMod); err != nil {
 		return err

--- a/pkg/cataloghtml/css.css
+++ b/pkg/cataloghtml/css.css
@@ -102,6 +102,15 @@ body > input {
 	min-height: 100%;
 }
 
+code {
+	overflow-x: auto;
+	white-space: pre-wrap;
+	white-space: -moz-pre-wrap;
+	white-space: -pre-wrap;
+	white-space: -o-pre-wrap;
+	word-wrap: break-word;
+}
+
 /* Structural classes */
 
 .header {

--- a/pkg/cataloghtml/css.css
+++ b/pkg/cataloghtml/css.css
@@ -103,12 +103,7 @@ body > input {
 }
 
 code {
-	overflow-x: auto;
 	white-space: pre-wrap;
-	white-space: -moz-pre-wrap;
-	white-space: -pre-wrap;
-	white-space: -o-pre-wrap;
-	word-wrap: break-word;
 }
 
 /* Structural classes */

--- a/wfapi/error.go
+++ b/wfapi/error.go
@@ -83,7 +83,7 @@ func ErrorUnknown(msgTmpl string, cause error) Error {
 func ErrorInternal(msgTmpl string, cause error) Error {
 	return &ErrorVal{
 		CodeString: "warpforge-error-internal",
-		Message:    msgTmpl,
+		Message:    fmt.Sprintf("%s (cause: %s)", msgTmpl, cause),
 		Cause:      wrapErr(cause),
 	}
 }


### PR DESCRIPTION
This adds HTML output for replay plots and download links to release pages. The replay plots are indented, syntax highlighted (using [Chroma](https://github.com/alecthomas/chroma)). Catalog refs in the replay plots are also given links to the relevant release.

It has some issues currently: 

1. The replay link doesn't seem to be clickable (on Firefox at least)
2. Syntax highlighting doesn't follow the style background color.